### PR TITLE
Fix: specify registry-url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
               with:
                   node-version: '${{ matrix.node-version }}'
                   yarn-version: '1.22.19'
+                  registry-url: 'https://registry.npmjs.org'
 
             - uses: 'actions/cache@v3'
               id: cache-install
@@ -169,7 +170,7 @@ jobs:
             - if: github.event_name == 'release' && github.event.action == 'published' && startsWith(github.ref, 'refs/tags/openrosa-xpath-evaluator/') && matrix.node-version == '20.5.1'
               run: yarn workspace openrosa-xpath-evaluator publish
               env:
-                  NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
     test-transformer:
         needs: ['install-and-build', 'changes']
@@ -198,6 +199,7 @@ jobs:
               with:
                   node-version: '${{ matrix.node-version }}'
                   yarn-version: '1.22.19'
+                  registry-url: 'https://registry.npmjs.org'
 
             - uses: 'actions/cache@v3'
               id: cache-install
@@ -230,7 +232,7 @@ jobs:
             - if: github.event_name == 'release' && github.event.action == 'published' && startsWith(github.ref, 'refs/tags/enketo-transformer/') && matrix.target == 'Node' && matrix.node-version == '20.5.1'
               run: yarn workspace enketo-transformer publish
               env:
-                  NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
     test-core:
         needs: ['install-and-build', 'changes']
@@ -249,6 +251,7 @@ jobs:
               with:
                   node-version: '${{ matrix.node-version }}'
                   yarn-version: '1.22.19'
+                  registry-url: 'https://registry.npmjs.org'
 
             - uses: 'actions/cache@v3'
               id: cache-install
@@ -283,7 +286,7 @@ jobs:
             - if: github.event_name == 'release' && github.event.action == 'published' && startsWith(github.ref, 'refs/tags/enketo-core/') && matrix.target == 'Node' && matrix.node-version == '20.5.1'
               run: yarn workspace enketo-core publish
               env:
-                  NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
     test-express:
         needs: ['install-and-build', 'changes']


### PR DESCRIPTION
According to [`volta-cli/action`](https://github.com/volta-cli/action), this should also ensure the auth token is included on publish requests. I’ve refrained from setting `always-auth` for now because it would need the token globally, which seems ill advised.

I also went ahead and matched the `secrets.NPM_TOKEN` case, just to be extra certain that's not an issue (even though it has not been in the other repos).