### PR TITLE
Fix: be able to publish enketo-express to Docker Hub

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -5,11 +5,46 @@ on:
         # Don't waste time building every push: consider only tags, which are
         # usually releases
         tags:
-            - 'enketo-express/*'
+            - '*'
 
 jobs:
     docker-build-push:
         runs-on: ubuntu-latest
+        # The intent here is to check for "not prefixed". The reason to even have
+        # that intent in the first place is that there's no clear, proscribed way
+        # to get a substring (any substring), or do substring replacement in GitHub
+        # Actions syntax. So it is not possible to derive an unprefixed tag from
+        # a tag prefixed `enketo-express/`, which we had originally intended to do.
+        #
+        # So the workaround is "don't prefix enketo-express releases". The logic
+        # to check "not prefixed" is also not possible, for the same underlying
+        # reason: to check "not prefixed", we'd want to know if the tag name has
+        # a slash. We can't know that, because `github.ref` always has slashes,
+        # i.e. `refs/tags/unprefixed-tag-name`.
+        #
+        # So the next workaround is to enumerate all of the known prefixes we do
+        # not want to match.
+        #
+        # And then the syntax gets weird, because we're writing code, in the
+        # GitHub Actions DSL, within a string in YAML syntax. "Not" in GHA DSL
+        # is predictably expressed with `!`, which evidently has special meaning
+        # in YAML... which in turn causes a YAML syntax error at `,`.
+        #
+        # So then the GHA-DSL-code-in-YAML-string must be explicitly quoted. The
+        # actual GHA-DSL-code-in-YAML-string also contains quoted strings, and
+        # those quotes must not conflict. Double quotes also produces a syntax
+        # error, this time in the GHA DSL. Backslashes are ostensibly the correct
+        # mechanism to escape double quotes, but not single quotes: they are also
+        # a syntax error (only detectable by running the Action on GitHub).
+        #
+        # No, to escape single quotes in GHA-DSL-code-in-YAML-string, you must use
+        # double-single-quotes-within-single-quotes. So that is what we've got in
+        # this line here.
+        #
+        # That's not all. For VSCode users: if you need to edit this file, to save
+        # you must call the "File: Save without Formatting" command, lest it be
+        # reformatted with invalid double quotes.
+        if: '!startsWith(github.ref, ''refs/tags/openrosa-xpath-evaluator/'') && !startsWith(github.ref, ''refs/tags/enketo-transformer/'') && !startsWith(github.ref, ''refs/tags/enketo-core/'')'
         steps:
             - uses: actions/checkout@v2
             - uses: mr-smithers-excellent/docker-build-push@v2


### PR DESCRIPTION
This removes the check for `enketo-express/` tag prefixes for publishing to Docker Hub, and adds exceptions to prevent publishing non-enketo-express releases.
