### PR TITLE
Update OSM URLs to one that supports HTTP/2 and HTTP/3

### DIFF
--- a/packages/enketo-core/README.md
+++ b/packages/enketo-core/README.md
@@ -108,7 +108,7 @@ The `maps` configuration can include an array of Mapbox TileJSON objects (or a s
 [
   {
     "name": "street",
-    "tiles": [ "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" ],
+    "tiles": [ "https://tile.openstreetmap.org/{z}/{x}/{y}.png" ],
     "attribution": "Map data © <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors"
   },
   {

--- a/packages/enketo-core/config.js
+++ b/packages/enketo-core/config.js
@@ -19,7 +19,7 @@ export default /** @type {const} */ ({
 
     maps: [
         {
-            tiles: ['https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'],
+            tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
             name: 'streets',
             attribution:
                 "© <a href='http://openstreetmap.org'>OpenStreetMap</a> | <a href='www.openstreetmap.org/copyright'>Terms</a>",

--- a/packages/enketo-core/src/widget/geo/geopicker.js
+++ b/packages/enketo-core/src/widget/geo/geopicker.js
@@ -31,7 +31,7 @@ const maps =
               {
                   name: 'streets',
                   maxzoom: 24,
-                  tiles: ['https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'],
+                  tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
                   attribution:
                       '© <a href="http://openstreetmap.org">OpenStreetMap</a> | <a href="www.openstreetmap.org/copyright">Terms</a>',
               },

--- a/packages/enketo-express/config/default-config.json
+++ b/packages/enketo-express/config/default-config.json
@@ -80,7 +80,7 @@
     "maps": [
         {
             "name": "streets",
-            "tiles": ["https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"],
+            "tiles": ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
             "attribution": "© <a href=\"http://openstreetmap.org\">OpenStreetMap</a> | <a href=\"www.openstreetmap.org/copyright\">Terms</a>"
         }
     ],

--- a/packages/enketo-express/config/sample.env
+++ b/packages/enketo-express/config/sample.env
@@ -56,10 +56,10 @@
 # ENKETO_PIWIK_ANALYTICS_SITE_ID=
 
 # ENKETO_MAPS_0_NAME=streets
-# ENKETO_MAPS_0_TILES_0=https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
+# ENKETO_MAPS_0_TILES_0=https://tile.openstreetmap.org/{z}/{x}/{y}.png
 # ENKETO_MAPS_0_ATTRIBUTION=© <a href="http://openstreetmap.org">OpenStreetMap</a> | <a href="www.openstreetmap.org/copyright">Terms</a>
 # ENKETO_MAPS_1_NAME=a
-# ENKETO_MAPS_1_TILES_0=https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
+# ENKETO_MAPS_1_TILES_0=https://tile.openstreetmap.org/{z}/{x}/{y}.png
 # ENKETO_MAPS_1_ATTRIBUTION=© <a href="http://openstreetmap.org">OpenStreetMap</a> | <a href="www.openstreetmap.org/copyright">Terms</a>
 
 # ENKETO_QUERY_PARAMETER_TO_PASS_TO_SUBMISSION=

--- a/packages/enketo-express/tutorials/10-configure.md
+++ b/packages/enketo-express/tutorials/10-configure.md
@@ -147,7 +147,7 @@ The `maps` configuration can include an array of Mapbox TileJSON objects (or a s
 ```
 [ {
         "name": "street",
-        "tiles": [ "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" ],
+        "tiles": [ "https://tile.openstreetmap.org/{z}/{x}/{y}.png" ],
         "attribution": "Map data © <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors"
     }, {
         "name": "satellite",


### PR DESCRIPTION
Updates OSM URLs per https://github.com/enketo/enketo-core/pull/998, https://github.com/openstreetmap/operations/issues/737

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [x] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?
Built and ran core, verified I can see OSM tiles.

#### Why is this the best possible solution? Were any other approaches considered?
I did a search for "tile.openstreetmap" to make sure I got all instances.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think the simple check I made is enough to feel confident this works. Worst case would be maps with OSM tiles don't work at all.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with a geo widget.