### PR TITLE
Fix: "for" attribute throws off ability to open to the right page upo…

### DIFF
--- a/packages/enketo-core/src/js/page.js
+++ b/packages/enketo-core/src/js/page.js
@@ -113,12 +113,12 @@ export default {
      */
     flipToPageContaining($e) {
         const e = $e[0];
-        const closest = e.closest('[role="page"]');
+        const closestPage = e.closest('[role="page"]');
 
-        if (closest) {
-            this._flipTo(closest);
-        } else {
-            // If $e is a comment question, and it is not inside a group, there will be no closest.
+        if (closestPage) {
+            this._flipTo(closestPage);
+        } else if (e.closest('.question')) {
+            // If $e is a comment question, and it is not inside a group, there will be no closestPage.
             const referer = e.querySelector('[data-for]');
             const ancestor = e.closest('.or-repeat, form.or');
             if (referer && ancestor) {

--- a/packages/enketo-core/test/forms/focus.xml
+++ b/packages/enketo-core/test/forms/focus.xml
@@ -45,7 +45,8 @@
 
             <bind nodeset="/data/group-page/group-readonly-empty-field" readonly="true()" />
             <bind nodeset="/data/group-page/group-readonly-calc-field" readonly="true()" calculate="'calculated'" />
-            <bind nodeset="/data/group-page/group-field" />
+            <!-- "enk:for" attribute bug: https://github.com/enketo/enketo/issues/1285 -->
+            <bind nodeset="/data/group-page/group-field" enk:for="/data/group-page/group-field2" />
             <bind nodeset="/data/group-page/group-field2" />
 
             <bind nodeset="/data/repeats-page/repeats-readonly-empty-field" readonly="true()" />


### PR DESCRIPTION
…n load, closes #1285

Closes #1285

#### I have verified this PR works with

- [x]  loading an online-only form

#### What else has been done to verify that this works as intended?

- [x] tweaked an existing test to fail for this issue

#### Why is this the best possible solution? Were any other approaches considered?

No other approaches were considered. [This](https://github.com/enketo/enketo-core/pull/969/files#diff-608210f16bb20aa58380a2606ca9a842e85e4634d9e3d03347845848b9bc0f8cR478) introduced the `form.or` element as a target for `goToTarget` during form initialization. This caused the regression.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I don't think there are regression risks

#### Do we need any specific form for testing your changes? If so, please attach one.

Yes, see issue #1285
