### PR TITLE
fixed: a loaded drawing/signature/annotation gets updated when nothin…

### DIFF
--- a/packages/enketo-core/src/widget/draw/draw-widget.js
+++ b/packages/enketo-core/src/widget/draw/draw-widget.js
@@ -49,7 +49,7 @@ class DrawWidget extends Widget {
                 penColor: that.props.colors[0] || 'black',
             });
 
-            this.pad.addEventListener('change', () => {
+            this.pad.addEventListener('endStroke', () => {
                 this._updateValue();
             });
 


### PR DESCRIPTION
…g changed, closes #1288

#### I have verified this PR works with

-   [x] loading and manually updating drawings


#### Why is this the best possible solution? Were any other approaches considered?

see comment below

#### Do we need any specific form for testing your changes? If so, please attach one.

any form with a drawing/annotation/signature should work
