### PR TITLE
Fixed _isRelevant function in calculation module returns incorrect ca…

### DIFF
--- a/packages/enketo-core/src/js/calculate.js
+++ b/packages/enketo-core/src/js/calculate.js
@@ -482,7 +482,7 @@ export default {
                         const preInitRelevance =
                             this.preInitRelevance.get(element);
 
-                        if (preInitRelevance != null) {
+                        if (preInitRelevance != null && !this.initialized ) {
                             return preInitRelevance;
                         }
 

--- a/packages/enketo-core/src/js/calculate.js
+++ b/packages/enketo-core/src/js/calculate.js
@@ -482,7 +482,7 @@ export default {
                         const preInitRelevance =
                             this.preInitRelevance.get(element);
 
-                        if (preInitRelevance != null && !this.initialized ) {
+                        if (preInitRelevance != null && !this.initialized) {
                             return preInitRelevance;
                         }
 

--- a/packages/enketo-core/test/spec/calculate.spec.js
+++ b/packages/enketo-core/test/spec/calculate.spec.js
@@ -684,18 +684,16 @@ describe('calculate functionality', () => {
         });
     });
 
-
     describe('function', () => {
-
         it('_isRelevant() determines relevancy correctly', () => {
             const form = loadForm('relevant-calcs.xml', null);
 
             form.init();
             const props = {
-                "name": "/data/grp/four",
-                "expr": "if( /data/a  != 'ignore', concat('fo', 'ur'), 'ignore')",
-                "dataType": "string",
-                "index": 0
+                name: '/data/grp/four',
+                expr: "if( /data/a  != 'ignore', concat('fo', 'ur'), 'ignore')",
+                dataType: 'string',
+                index: 0,
             };
 
             expect(form.calc._isRelevant(props)).to.equal(false);
@@ -707,6 +705,5 @@ describe('calculate functionality', () => {
 
             expect(form.calc._isRelevant(props)).to.equal(true);
         });
-
-    })
+    });
 });

--- a/packages/enketo-core/test/spec/calculate.spec.js
+++ b/packages/enketo-core/test/spec/calculate.spec.js
@@ -683,4 +683,30 @@ describe('calculate functionality', () => {
             expect(q2.value).to.equal('8');
         });
     });
+
+
+    describe('function', () => {
+
+        it('_isRelevant() determines relevancy correctly', () => {
+            const form = loadForm('relevant-calcs.xml', null);
+
+            form.init();
+            const props = {
+                "name": "/data/grp/four",
+                "expr": "if( /data/a  != 'ignore', concat('fo', 'ur'), 'ignore')",
+                "dataType": "string",
+                "index": 0
+            };
+
+            expect(form.calc._isRelevant(props)).to.equal(false);
+
+            const a = form.view.html.querySelector('input[name="/data/a"]');
+
+            a.value = 'a';
+            a.dispatchEvent(events.Change());
+
+            expect(form.calc._isRelevant(props)).to.equal(true);
+        });
+
+    })
 });


### PR DESCRIPTION
…ched result after initialization

It's a bit of an obscure issue due to the fact that in most of the Enketo world form values are never cleared when they become non-relevant. However, there are some remnants in the code (e.g. the `emptyNonRelevant` parameters at various places in calculate.js), that conflict with the `preInitRelevance` cache in calculate.js. See inline code comment below.

I had to write a unit test to demonstrate it and decided to do this at the lowest level since `_isRelevant` should probably always return a correct result no matter when it is called (so the test would survive any possible future removal of these emptyNonRelevant remnants). Though if you prefer I write a test for the `update` method, just let me know.