### PR TITLE
If redis is configured with a URL, use the url as-is

### DIFF
--- a/packages/enketo-express/app/lib/db.js
+++ b/packages/enketo-express/app/lib/db.js
@@ -1,26 +1,8 @@
 const redis = require('redis');
 const config = require('../models/config-model').server;
 
-/**
- * Creates the redis url passed into the client, taking the URL as is if defined, otherwise building the url from
- * the predefined host, port and option auth token
- *
- * @static
- * @param { object } redisConfig - Local redis configuration settings imported from the config model.
- * @return { string } Redis url
- */
-
-function _getRedisUrl(redisConfig) {
-    if (redisConfig.url) {
-        return redisConfig.url;
-    } else {
-        const auth = redisConfig.password ? `:${redisConfig.password}@` : '';
-        return `redis://${auth}${redisConfig.host}:${redisConfig.port}`;
-    }
-}
-
-const mainClient = redis.createClient(_getRedisUrl(config.redis.main));
-const cacheClient = redis.createClient(_getRedisUrl(config.redis.cache));
+const mainClient = redis.createClient(config.redis.main.url);
+const cacheClient = redis.createClient(config.redis.cache.url);
 
 module.exports = {
     mainClient,

--- a/packages/enketo-express/app/lib/db.js
+++ b/packages/enketo-express/app/lib/db.js
@@ -1,21 +1,26 @@
 const redis = require('redis');
 const config = require('../models/config-model').server;
 
-const mainClient = redis.createClient(
-    config.redis.main.port,
-    config.redis.main.host,
-    {
-        auth_pass: config.redis.main.password,
-    }
-);
+/**
+ * Creates the redis url passed into the client, taking the URL as is if defined, otherwise building the url from
+ * the predefined host, port and option auth token
+ *
+ * @static
+ * @param { object } redisConfig - Local redis configuration settings imported from the config model.
+ * @return { string } Redis url
+ */
 
-const cacheClient = redis.createClient(
-    config.redis.cache.port,
-    config.redis.cache.host,
-    {
-        auth_pass: config.redis.cache.password,
+function _getRedisUrl(redisConfig) {
+    if (redisConfig.url) {
+        return redisConfig.url
     }
-);
+    else {
+        return `redis://:${redisConfig.password}@${redisConfig.host}:${redisConfig.port}`
+    }
+}
+
+const mainClient = redis.createClient(_getRedisUrl(config.redis.main))
+const cacheClient = redis.createClient(_getRedisUrl(config.redis.cache))
 
 module.exports = {
     mainClient,

--- a/packages/enketo-express/app/lib/db.js
+++ b/packages/enketo-express/app/lib/db.js
@@ -12,15 +12,15 @@ const config = require('../models/config-model').server;
 
 function _getRedisUrl(redisConfig) {
     if (redisConfig.url) {
-        return redisConfig.url
-    }
-    else {
-        return `redis://:${redisConfig.password}@${redisConfig.host}:${redisConfig.port}`
+        return redisConfig.url;
+    } else {
+        const auth = redisConfig.password ? `:${redisConfig.password}@` : '';
+        return `redis://${auth}${redisConfig.host}:${redisConfig.port}`;
     }
 }
 
-const mainClient = redis.createClient(_getRedisUrl(config.redis.main))
-const cacheClient = redis.createClient(_getRedisUrl(config.redis.cache))
+const mainClient = redis.createClient(_getRedisUrl(config.redis.main));
+const cacheClient = redis.createClient(_getRedisUrl(config.redis.cache));
 
 module.exports = {
     mainClient,

--- a/packages/enketo-express/app/lib/db.js
+++ b/packages/enketo-express/app/lib/db.js
@@ -1,8 +1,17 @@
 const redis = require('redis');
 const config = require('../models/config-model').server;
 
-const mainClient = redis.createClient(config.redis.main.url);
-const cacheClient = redis.createClient(config.redis.cache.url);
+const mainClient = config.redis.main.url
+    ? redis.createClient(config.redis.main.url)
+    : redis.createClient(config.redis.main.port, config.redis.main.host, {
+          auth_pass: config.redis.main.password,
+      });
+
+const cacheClient = config.redis.cache.url
+    ? redis.createClient(config.redis.cache.url)
+    : redis.createClient(config.redis.cache.port, config.redis.cache.host, {
+          auth_pass: config.redis.cache.password,
+      });
 
 module.exports = {
     mainClient,

--- a/packages/enketo-express/app/models/config-model.js
+++ b/packages/enketo-express/app/models/config-model.js
@@ -36,8 +36,6 @@ try {
     _setRedisUrlsFromEnv();
 }
 
-_transformRedisConfigToUrls();
-
 /**
  * Updates all configuration items for which an environment variable was set.
  */
@@ -227,34 +225,6 @@ function _setRedisUrlsFromEnv() {
     if (process.env.ENKETO_REDIS_CACHE_URL) {
         config.redis.cache.url = process.env.ENKETO_REDIS_CACHE_URL;
     }
-}
-
-/**
- * If a redis URL is set, use that. Otherwise, build one from host/password/port configuration.
- */
-function _transformRedisConfigToUrls() {
-    if (!config.redis.main.url) {
-        config.redis.main.url = _buildRedisUrl(config.redis.main);
-    }
-
-    if (!config.redis.cache.url) {
-        config.redis.cache.url = _buildRedisUrl(config.redis.cache);
-    }
-}
-
-/**
- * Builds a redis url from configured host, port and optional password
- *
- * @static
- * @param { object } redisConfig - Local redis configuration settings imported from the config model.
- * @return { string } Redis url
- */
-
-function _buildRedisUrl(redisConfig) {
-    const auth = redisConfig.password
-        ? `:${encodeURIComponent(redisConfig.password)}@`
-        : '';
-    return `redis://${auth}${redisConfig.host}:${redisConfig.port}`;
 }
 
 /**

--- a/packages/enketo-express/app/models/config-model.js
+++ b/packages/enketo-express/app/models/config-model.js
@@ -251,7 +251,9 @@ function _transformRedisConfigToUrls() {
  */
 
 function _buildRedisUrl(redisConfig) {
-    const auth = redisConfig.password ? `:${redisConfig.password}@` : '';
+    const auth = redisConfig.password
+        ? `:${encodeURIComponent(redisConfig.password)}@`
+        : '';
     return `redis://${auth}${redisConfig.host}:${redisConfig.port}`;
 }
 

--- a/packages/enketo-express/app/models/config-model.js
+++ b/packages/enketo-express/app/models/config-model.js
@@ -222,31 +222,11 @@ function _setRedisConfigFromEnv() {
     const redisCacheUrl = process.env.ENKETO_REDIS_CACHE_URL;
 
     if (redisMainUrl) {
-        config.redis.main = _extractRedisConfigFromUrl(redisMainUrl);
+        config.redis.main.url = redisMainUrl;
     }
     if (redisCacheUrl) {
-        config.redis.cache = _extractRedisConfigFromUrl(redisCacheUrl);
+        config.redis.cache.url = redisCacheUrl;
     }
-}
-
-/**
- * Parses a redis URL and returns an object with `host`, `port` and `password` properties.
- *
- * @param { string } redisUrl - A compliant redis url
- * @return {{host: string, port: string, password: string|null}} config object
- */
-function _extractRedisConfigFromUrl(redisUrl) {
-    const parsedUrl = url.parse(redisUrl);
-    const password =
-        parsedUrl.auth && parsedUrl.auth.split(':')[1]
-            ? parsedUrl.auth.split(':')[1]
-            : null;
-
-    return {
-        host: parsedUrl.hostname,
-        port: parsedUrl.port,
-        password,
-    };
 }
 
 /**

--- a/packages/enketo-express/test/server/config-model.spec.js
+++ b/packages/enketo-express/test/server/config-model.spec.js
@@ -206,6 +206,17 @@ describe('Config Model', () => {
             );
         });
 
+        it('builds a redis url from components with password with special characters', () => {
+            stubEnv('ENKETO_REDIS_MAIN_HOST', 'ec2-5.compute-1.amazonaws.com');
+            stubEnv('ENKETO_REDIS_MAIN_PASSWORD', '&onBsidv6#XeKFd}=BDDyRrv:@');
+            stubEnv('ENKETO_REDIS_MAIN_PORT', '12');
+
+            config = loadConfig();
+            expect(config.server.redis.main.url).to.equal(
+                'redis://:%26onBsidv6%23XeKFd%7D%3DBDDyRrv%3A%40@ec2-5.compute-1.amazonaws.com:12'
+            );
+        });
+
         it('passes through a complex redis main URL', () => {
             stubEnv(
                 'ENKETO_REDIS_MAIN_URL',

--- a/packages/enketo-express/test/server/config-model.spec.js
+++ b/packages/enketo-express/test/server/config-model.spec.js
@@ -185,38 +185,6 @@ describe('Config Model', () => {
             expect(config.server.maps[2].tiles).to.deep.equal(['d', 'e']);
         });
 
-        it('builds a redis url from components without password', () => {
-            stubEnv('ENKETO_REDIS_CACHE_HOST', 'ec2-5.compute.amazonaws.com');
-            stubEnv('ENKETO_REDIS_CACHE_PORT', '12');
-
-            config = loadConfig();
-            expect(config.server.redis.cache.url).to.equal(
-                'redis://ec2-5.compute.amazonaws.com:12'
-            );
-        });
-
-        it('builds a redis url from components with password', () => {
-            stubEnv('ENKETO_REDIS_MAIN_HOST', 'ec2-5.compute-1.amazonaws.com');
-            stubEnv('ENKETO_REDIS_MAIN_PASSWORD', 'stilettos');
-            stubEnv('ENKETO_REDIS_MAIN_PORT', '12');
-
-            config = loadConfig();
-            expect(config.server.redis.main.url).to.equal(
-                'redis://:stilettos@ec2-5.compute-1.amazonaws.com:12'
-            );
-        });
-
-        it('builds a redis url from components with password with special characters', () => {
-            stubEnv('ENKETO_REDIS_MAIN_HOST', 'ec2-5.compute-1.amazonaws.com');
-            stubEnv('ENKETO_REDIS_MAIN_PASSWORD', '&onBsidv6#XeKFd}=BDDyRrv:@');
-            stubEnv('ENKETO_REDIS_MAIN_PORT', '12');
-
-            config = loadConfig();
-            expect(config.server.redis.main.url).to.equal(
-                'redis://:%26onBsidv6%23XeKFd%7D%3DBDDyRrv%3A%40@ec2-5.compute-1.amazonaws.com:12'
-            );
-        });
-
         it('passes through a complex redis main URL', () => {
             stubEnv(
                 'ENKETO_REDIS_MAIN_URL',

--- a/packages/enketo-express/test/server/config-model.spec.js
+++ b/packages/enketo-express/test/server/config-model.spec.js
@@ -185,17 +185,49 @@ describe('Config Model', () => {
             expect(config.server.maps[2].tiles).to.deep.equal(['d', 'e']);
         });
 
-        it('parses a redis url to its components', () => {
+        it('builds a redis url from components without password', () => {
+            stubEnv('ENKETO_REDIS_CACHE_HOST', 'ec2-5.compute.amazonaws.com');
+            stubEnv('ENKETO_REDIS_CACHE_PORT', '12');
+
+            config = loadConfig();
+            expect(config.server.redis.cache.url).to.equal(
+                'redis://ec2-5.compute.amazonaws.com:12'
+            );
+        });
+
+        it('builds a redis url from components with password', () => {
+            stubEnv('ENKETO_REDIS_MAIN_HOST', 'ec2-5.compute-1.amazonaws.com');
+            stubEnv('ENKETO_REDIS_MAIN_PASSWORD', 'stilettos');
+            stubEnv('ENKETO_REDIS_MAIN_PORT', '12');
+
+            config = loadConfig();
+            expect(config.server.redis.main.url).to.equal(
+                'redis://:stilettos@ec2-5.compute-1.amazonaws.com:12'
+            );
+        });
+
+        it('passes through a complex redis main URL', () => {
             stubEnv(
                 'ENKETO_REDIS_MAIN_URL',
-                'redis://h:pwd@ec2-54-221-230-53.compute-1.amazonaws.com:6869'
+                'rediss://user:pass@ec2-5.compute-1.amazonaws.com:12/14'
             );
+
             config = loadConfig();
-            expect(config.server.redis.main.host).to.equal(
-                'ec2-54-221-230-53.compute-1.amazonaws.com'
+            expect(config.server.redis.main.url).to.equal(
+                'rediss://user:pass@ec2-5.compute-1.amazonaws.com:12/14'
             );
-            expect(config.server.redis.main.port).to.equal('6869');
-            expect(config.server.redis.main.password).to.equal('pwd');
+        });
+
+        it('passes through a complex redis cache URL', () => {
+            stubEnv(
+                'ENKETO_REDIS_CACHE_URL',
+                'rediss://user:pass@ec2-5.compute-1.amazonaws.com:12/14'
+            );
+
+            config = loadConfig();
+            expect(config.server.redis.cache.url).to.equal(
+                'rediss://user:pass@ec2-5.compute-1.amazonaws.com:12/14'
+            );
         });
     });
 

--- a/packages/enketo-express/tutorials/10-configure.md
+++ b/packages/enketo-express/tutorials/10-configure.md
@@ -1,4 +1,6 @@
-Below is a complete list of all configuration items. The **bold items** also highlighted with 👉 are important to set. Others are less important.
+Below is a complete list of all configuration items. These are set in the `config.json` file or environment variables as described [in the README](./packages/enketo-express#configuring-enketo-express).
+
+The **bold items** also highlighted with 👉 are important to set. Others are less important.
 
 ## app name
 
@@ -162,6 +164,9 @@ For GMaps layers you have the four options as tiles values: `"GOOGLE_SATELLITE"`
 Specifies the name of a query parameter that will be copied from an Enketo URL to the submission and formList requests. The value of this parameter can be used by the data server to e.g. track submission sources, perform form access control, or serve custom external data per user.
 
 ## 👉 redis
+
+> [!NOTE]
+> You can use `main -> url` or `cache --> url` or the corresponding environmental variables instead of the host/port/password combination described below. Use a URL to specify additional Redis configuration such as SSL, username, or DB index. A URL takes precedence over the separate configuration items.
 
 -   main -> host: The IP address of the main redis database instance. If installed on the same server as Enketo Express, the value is `"127.0.0.1"`
 -   👉 **main -> port**: The port of the main redis database instance. This is the important persistent database that contains the unique IDs for each forms. The default value is `"6379"`


### PR DESCRIPTION
Currently, there is now way to use Enekto with REDIS over TLS, which is very common at least in public cloud environments such as AWS and Azure. This PR aims to create a backwards compatible way to specify that configuration. The current configuration does allow for a full URL, but it just parses the url to get the separate configuration items, such as password, host, etc. So even if a user does supply a full url, such as `rediss://pass@host`, the `rediss` part is thrown out. This PR takes a user specified URL and uses it as is and only builds the URL if the users specifies the individual components as separate configuration items.

Closes #15 

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [x ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?
We using this in our own environment using the ENKETO_REDIS_MAIN_URL and ENKETO_REDIS_CACHE_URL environment variables

#### Why is this the best possible solution? Were any other approaches considered?
Perhaps a better solution would be to fully support Redis configuration with SSL enabled, but the current settings do not do that. This method also has the advantage that users could add other flags or settings as needed

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Configuration with the individual password, hostname and port settings could be affected i suppose if we misunderstood how they are used.

#### Do we need any specific form for testing your changes? If so, please attach one.
