### PR TITLE
Add support to Redis db index

### DIFF
--- a/packages/enketo-express/app/lib/db.js
+++ b/packages/enketo-express/app/lib/db.js
@@ -6,6 +6,7 @@ const mainClient = redis.createClient(
     config.redis.main.host,
     {
         auth_pass: config.redis.main.password,
+        db: config.redis.main?.db || 0,
     }
 );
 
@@ -14,6 +15,7 @@ const cacheClient = redis.createClient(
     config.redis.cache.host,
     {
         auth_pass: config.redis.cache.password,
+        db: config.redis.cache?.db || 0,
     }
 );
 

--- a/packages/enketo-express/app/models/config-model.js
+++ b/packages/enketo-express/app/models/config-model.js
@@ -241,10 +241,14 @@ function _extractRedisConfigFromUrl(redisUrl) {
         parsedUrl.auth && parsedUrl.auth.split(':')[1]
             ? parsedUrl.auth.split(':')[1]
             : null;
+    const dbIndex = parsedUrl.path 
+        ? parsedUrl.path.substr(1)
+        : 0;
 
     return {
         host: parsedUrl.hostname,
         port: parsedUrl.port,
+        db: dbIndex,
         password,
     };
 }

--- a/packages/enketo-express/app/models/config-model.js
+++ b/packages/enketo-express/app/models/config-model.js
@@ -241,9 +241,7 @@ function _extractRedisConfigFromUrl(redisUrl) {
         parsedUrl.auth && parsedUrl.auth.split(':')[1]
             ? parsedUrl.auth.split(':')[1]
             : null;
-    const dbIndex = parsedUrl.path 
-        ? parsedUrl.path.substr(1)
-        : 0;
+    const dbIndex = parsedUrl.path ? parsedUrl.path.substring(1) : 0;
 
     return {
         host: parsedUrl.hostname,

--- a/packages/enketo-express/config/default-config.json
+++ b/packages/enketo-express/config/default-config.json
@@ -89,12 +89,14 @@
         "main": {
             "host": "127.0.0.1",
             "port": "6379",
-            "password": null
+            "password": null,
+            "db": 0
         },
         "cache": {
             "host": "127.0.0.1",
             "port": "6380",
-            "password": null
+            "password": null,
+            "db": 0
         }
     },
     "logo": {

--- a/packages/enketo-express/config/sample.env
+++ b/packages/enketo-express/config/sample.env
@@ -67,14 +67,23 @@
 # ENKETO_REDIS_MAIN_HOST=127.0.0.1
 # ENKETO_REDIS_MAIN_PORT=6379
 # ENKETO_REDIS_MAIN_PASSWORD=null
-# or alternatively, instead of above 3 variables:
+# or alternatively, instead of above 3 variables: 
 # ENKETO_REDIS_MAIN_URL=redis://h:pwd@ec2-54-221-230-53.compute-1.amazonaws.com:6869
+# Database index can also be specified…
+# ENKETO_REDIS_MAIN_DB=1
+# …or as an URL
+# ENKETO_REDIS_MAIN_URL=redis://h:pwd@ec2-54-221-230-53.compute-1.amazonaws.com:6869/1
 
 # ENKETO_REDIS_CACHE_HOST=127.0.0.1
 # ENKETO_REDIS_CACHE_PORT=6380
 # ENKETO_REDIS_CACHE_PASSWORD=null
 # or alternatively, instead of above 3 variables:
 # ENKETO_REDIS_CACHE_URL=redis://h:pwd@ec2-54-221-230-53.compute-1.amazonaws.com:6869
+# Database index can also be specified…
+# ENKETO_REDIS_CACHE_DB=1
+# …or as an URL
+# ENKETO_REDIS_CACHE_URL=redis://h:pwd@ec2-54-221-230-53.compute-1.amazonaws.com:6869/1
+
 
 # ENKETO_LOGO_SOURCE=/path/to/image.png
 # ENKETO_LOGO_HREF=

--- a/packages/enketo-express/test/server/config-model.spec.js
+++ b/packages/enketo-express/test/server/config-model.spec.js
@@ -196,6 +196,35 @@ describe('Config Model', () => {
             );
             expect(config.server.redis.main.port).to.equal('6869');
             expect(config.server.redis.main.password).to.equal('pwd');
+            expect(config.server.redis.main.db).to.equal(0);
+        });
+
+        it('parses a redis main url with db index to its components', () => {
+            stubEnv(
+                'ENKETO_REDIS_MAIN_URL',
+                'redis://h:pwd@ec2-54-221-230-53.compute-1.amazonaws.com:6869/4'
+            );
+            config = loadConfig();
+            expect(config.server.redis.main.host).to.equal(
+                'ec2-54-221-230-53.compute-1.amazonaws.com'
+            );
+            expect(config.server.redis.main.port).to.equal('6869');
+            expect(config.server.redis.main.password).to.equal('pwd');
+            expect(config.server.redis.main.db).to.equal(4);
+        });
+
+        it('parses a redis cache url with db index to its components', () => {
+            stubEnv(
+                'ENKETO_REDIS_CACHE_URL',
+                'redis://h:cache_pwd@ec2-54-221-230-53.compute-1.amazonaws.com:6380/5'
+            );
+            config = loadConfig();
+            expect(config.server.redis.cache.host).to.equal(
+                'ec2-54-221-230-53.compute-1.amazonaws.com'
+            );
+            expect(config.server.redis.cache.port).to.equal('6380');
+            expect(config.server.redis.cache.password).to.equal('cache_pwd');
+            expect(config.server.redis.cache.db).to.equal(5);
         });
     });
 

--- a/packages/enketo-express/test/server/config-model.spec.js
+++ b/packages/enketo-express/test/server/config-model.spec.js
@@ -210,7 +210,7 @@ describe('Config Model', () => {
             );
             expect(config.server.redis.main.port).to.equal('6869');
             expect(config.server.redis.main.password).to.equal('pwd');
-            expect(config.server.redis.main.db).to.equal(4);
+            expect(config.server.redis.main.db).to.equal('4');
         });
 
         it('parses a redis cache url with db index to its components', () => {
@@ -224,7 +224,7 @@ describe('Config Model', () => {
             );
             expect(config.server.redis.cache.port).to.equal('6380');
             expect(config.server.redis.cache.password).to.equal('cache_pwd');
-            expect(config.server.redis.cache.db).to.equal(5);
+            expect(config.server.redis.cache.db).to.equal('5');
         });
     });
 


### PR DESCRIPTION
#### I have verified this PR works with

-   [x] Online form submission
-   [x] Offline form submission
-   [x] Saving offline drafts
-   [x] Loading offline drafts
-   [x] Editing submissions
-   [x] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

Monitor Redis to ensure it does send "select `<db index>`" before sending the command

#### Why is this the best possible solution? Were any other approaches considered?

Maybe some of my PR could be merged with #1297 since the latter gives more leeway when using redis URLs. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There should not be any regression risk because it falls back on db index 0 like it is in the current release. However, it lets the sysadmin to use 2 different databases when using only one instance of redis.

#### Do we need any specific form for testing your changes? If so, please attach one.
