### PR TITLE
Forward auth cookie when making max-size request to form server

### DIFF
--- a/packages/enketo-express/app/controllers/submission-controller.js
+++ b/packages/enketo-express/app/controllers/submission-controller.js
@@ -154,6 +154,7 @@ function maxSize(req, res, next) {
         surveyModel
             .get(req.enketoId)
             .then((survey) => {
+                survey.cookie = req.headers.cookie;
                 survey.credentials = userModel.getCredentials(req);
 
                 return survey;


### PR DESCRIPTION
Closes: https://github.com/enketo/enketo/issues/994
Closes: https://github.com/onaio/onadata/issues/2568

#### I have verified this PR works with

-   [x] Online form submission
-   [x] Offline form submission
-   [x] Saving offline drafts
-   [x] Loading offline drafts
-   [x] Editing submissions
-   [x] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?
Tested locally

#### Why is this the best possible solution? Were any other approaches considered?
Yes, I considered [allowing HEAD requests on this endpoint to be unauthenticated on onadata side
](https://github.com/onaio/onadata/pull/2565)
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risks that I can think of

#### Do we need any specific form for testing your changes? If so, please attach one.
No
