### PR TITLE
enketo-express/test/survey-model: reduce test flake

### DIFF
--- a/packages/enketo-express/test/server/survey-model.spec.js
+++ b/packages/enketo-express/test/server/survey-model.spec.js
@@ -12,11 +12,12 @@ const { expect } = chai;
 
 // help function to ensure subsequent database entries don't have the exact same timestamp
 // redis is fast...
-const _wait1ms = () =>
+// 1ms is not enough to guarantee ISO timestamps are different.
+const _wait2ms = () =>
     new Promise((resolve) => {
         setTimeout(() => {
             resolve();
-        }, 1);
+        }, 2);
     });
 
 describe('Survey Model', () => {
@@ -356,9 +357,9 @@ describe('Survey Model', () => {
             const getNumber = model
                 .set(survey1)
                 .then(() => model.set(survey2))
-                .then(_wait1ms)
+                .then(_wait2ms)
                 .then(() => model.set(survey3))
-                .then(_wait1ms)
+                .then(_wait2ms)
                 .then(() => model.set(survey4))
                 .then(() => model.getNumber(server));
             return expect(getNumber).to.eventually.equal(3);
@@ -368,9 +369,9 @@ describe('Survey Model', () => {
             const getNumber = model
                 .set(survey1)
                 .then(() => model.set(survey2))
-                .then(_wait1ms)
+                .then(_wait2ms)
                 .then(() => model.set(survey3))
-                .then(_wait1ms)
+                .then(_wait2ms)
                 .then(() => model.set(survey4))
                 .then(() =>
                     model.update({
@@ -408,11 +409,11 @@ describe('Survey Model', () => {
         it('obtains the list surveys if all are active in ascending launch date order', () => {
             const getList = model
                 .set(survey1)
-                .then(_wait1ms)
+                .then(_wait2ms)
                 .then(() => model.set(survey2))
-                .then(_wait1ms)
+                .then(_wait2ms)
                 .then(() => model.set(survey3))
-                .then(_wait1ms)
+                .then(_wait2ms)
                 .then(() => model.set(survey4))
                 .then(() => model.getList(server))
                 .then((list) =>
@@ -441,11 +442,11 @@ describe('Survey Model', () => {
         it('obtains the list of active surveys only', () => {
             const getList = model
                 .set(survey1)
-                .then(_wait1ms)
+                .then(_wait2ms)
                 .then(() => model.set(survey2))
-                .then(_wait1ms)
+                .then(_wait2ms)
                 .then(() => model.set(survey3))
-                .then(_wait1ms)
+                .then(_wait2ms)
                 .then(() => model.set(survey4))
                 .then(() =>
                     model.update({


### PR DESCRIPTION
Occasional test failures can be seen in Survey Model tests, e.g. https://github.com/enketo/enketo/actions/runs/8701494028/job/23863630099:

```
1) Survey Model
       getList
         obtains the list surveys if all are active in ascending launch date order:

      AssertionError: expected [ { …(2) }, { …(2) }, { …(2) } ] to deeply equal [ { …(2) }, { …(2) }, { …(2) } ]
      + expected - actual

           "openRosaId": "a"
           "openRosaServer": "https://kobotoolbox.org/enketo"
         }
         {
      +    "openRosaId": "b"
      +    "openRosaServer": "https://kobotoolbox.org/enketo"
      +  }
      +  {
           "openRosaId": "c"
           "openRosaServer": "https://kobotoolbox.org/enketo/deep"
         }
      -  {
      -    "openRosaId": "b"
      -    "openRosaServer": "https://kobotoolbox.org/enketo"
      -  }
       ]

      at /home/runner/work/enketo/enketo/node_modules/chai-as-promised/lib/chai-as-promised.js:302:22
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This appears to be due to timestamp collisions causing `surveys.sort(_ascendingLaunchDate)` to be unstable.

Creating two Date objects 1ms apart in javascript does not guarantee they will have been created in different clock milliseconds.  This can be demonstrated:

```js
const DELAY = 1;
let start, end, iterations;
iterations = 0;
const recordEnd = () => {
  end = new Date();
  if(start.toISOString() === end.toISOString()) {
    throw new Error(`Start and end matched after ${iterations} iterations`);
  } else repeat();
};
const repeat = () => {
  ++iterations;
  start = new Date();
  setTimeout(recordEnd, DELAY);
};
repeat();
```

On my machine, a 1ms delay will cause failure after ~10 iterations.  A 2ms delay will not fail before I get bored of waiting.
