### PR TITLE
Use slim node image, clean cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM node:20.12.2-slim
 
 RUN apt-get update || : && apt-get install -y \
     python3 \
-    build-essential
+    build-essential \
+    jq
 
 ENV ENKETO_SRC_DIR=/srv/src/enketo
 WORKDIR ${ENKETO_SRC_DIR}
@@ -11,7 +12,7 @@ COPY . ${ENKETO_SRC_DIR}
 
 # Install and build, first with dev dependencies, then with production only (yarn 1 has no prune)
 RUN yarn install --frozen-lockfile \
-    && rm -rf node_modules \
+    && yarn remove $(cat package.json | jq -r '.devDependencies | keys | join(" ")') -W \
     && yarn install --production --frozen-lockfile --ignore-scripts \
     && yarn cache clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,8 @@ WORKDIR ${ENKETO_SRC_DIR}
 
 COPY . ${ENKETO_SRC_DIR}
 
-# Install and build, first with dev dependencies, then with production only (yarn 1 has no prune)
+# Install and build, leaving dev dependencies (yarn 1 has no prune)
 RUN yarn install --frozen-lockfile \
-    && yarn remove $(cat package.json | jq -r '.devDependencies | keys | join(" ")') -W \
-    && yarn install --production --frozen-lockfile --ignore-scripts \
     && yarn cache clean
 
 EXPOSE 8005

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:20.12.2-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         python3 \
-        build-essential
+        build-essential \
+        git
 
 ENV ENKETO_SRC_DIR=/srv/src/enketo
 WORKDIR ${ENKETO_SRC_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:20.12.2-slim
 
-RUN apt-get update || : && apt-get install -y \
-    python3 \
-    build-essential \
-    jq
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 \
+        build-essential
 
 ENV ENKETO_SRC_DIR=/srv/src/enketo
 WORKDIR ${ENKETO_SRC_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
-FROM node:20.12.2
+FROM node:20.12.2-slim
+
+RUN apt-get update || : && apt-get install -y \
+    python3 \
+    build-essential
 
 ENV ENKETO_SRC_DIR=/srv/src/enketo
 WORKDIR ${ENKETO_SRC_DIR}
 
 COPY . ${ENKETO_SRC_DIR}
 
-# Install (including dev dependencies) and build
-RUN yarn install --frozen-lockfile
-
-# Remove dev dependencies after build
-RUN yarn install --production --frozen-lockfile --ignore-scripts
+# Install and build, first with dev dependencies, then with production only (yarn 1 has no prune)
+RUN yarn install --frozen-lockfile \
+    && rm -rf node_modules \
+    && yarn install --production --frozen-lockfile --ignore-scripts \
+    && yarn cache clean
 
 EXPOSE 8005
 


### PR DESCRIPTION
Reduce the image size. It was over 1.6Gb compressed because of the double `yarn install`. The second `yarn install` was not doing anything: `yarn` v1 doesn't do any pruning of existing installed deps with `--production`: https://github.com/yarnpkg/yarn/issues/6373, https://github.com/yarnpkg/yarn/issues/696

#### I have verified this PR works with

-   [x] Online form submission
-   [x] Offline form submission
-   [x] Saving offline drafts
-   [x] Loading offline drafts
-   [x] Editing submissions
-   [x] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?
Tried integrated with ODK Central.

#### Why is this the best possible solution? Were any other approaches considered?
There's more to do but I think we should start with this which gets to a compressed image of about 800Mb. This makes a big difference in install time, even on fast connections.

I had hoped to prune dev dependencies and I think https://github.com/enketo/enketo/pull/1309/commits/2469791fdb15ecba8ff839c180e6ee9f5da6baba is a reasonable way but @alxndrsn is less comfortable with it. I'd rather go with an approach we all feel is safe, the diff is 70mb and the dev dependencies should not pose any risk. I think the next step will be to come back to this and take a multistage approach.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think given that I've run it with a form server the risks are very low. The changes are all implementation details and shouldn't change anything for downstream users.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.
