### PR TITLE
[Form redirection option] - Reopen empty form after submit

### DIFF
--- a/packages/enketo-express/app/models/config-model.js
+++ b/packages/enketo-express/app/models/config-model.js
@@ -349,6 +349,7 @@ module.exports = {
         csrfCookieName: config['csrf cookie name'],
         excludeNonRelevant: config['exclude non-relevant'],
         experimentalOptimizations: config['experimental optimizations'],
+        redirectToForm: config.redirectToForm,
     },
     getThemesSupported,
 };

--- a/packages/enketo-express/config/default-config.json
+++ b/packages/enketo-express/config/default-config.json
@@ -123,5 +123,6 @@
     "exclude non-relevant": false,
     "experimental optimizations": {
         "computeAsync": false
-    }
+    },
+    "redirectToForm": false
 }

--- a/packages/enketo-express/public/js/src/module/controller-webform.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform.js
@@ -1,7 +1,7 @@
 /**
  * Deals with the main high level survey controls: saving, submitting etc.
  */
-
+import config from 'enketo/config';
 import { Form } from 'enketo-core';
 import downloadUtils from 'enketo-core/src/js/download-utils';
 import $ from 'jquery';
@@ -438,9 +438,13 @@ function _submitRecord(survey) {
                 msg += t('alert.submissionsuccess.redirectmsg');
                 gui.alert(msg, t('alert.submissionsuccess.heading'), level);
                 setTimeout(() => {
-                    location.href = decodeURIComponent(
-                        settings.returnUrl || settings.defaultReturnUrl
-                    );
+                    if (config.redirectToForm == true){
+                        location.href = window.location.href;
+                    } else {
+                        location.href = decodeURIComponent(
+                            settings.returnUrl || settings.defaultReturnUrl
+                        );
+                    }
                 }, 1200);
             } else {
                 msg = msg.length > 0 ? msg : t('alert.submissionsuccess.msg');


### PR DESCRIPTION
Closes #

#### I have verified this PR works with

-   [x] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [x] Editing submissions - But keep original redirection to the thanks page because in editing redirection already made (I don't know really where...)
-   [x] Form preview
-   [ ] None of the above

#### Why is this the best possible solution? Were any other approaches considered?

Admin can choose if he want to active or not the redirection to a new empty form by specifying the value of "redirectToForm" in enketo-express/config/config.json.template file

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

If redirectToForm = true, the user can submit more easly many forms. He don't need to click again on public url to go back on the form page and submit another.
.
