### PR TITLE
Add multi-argument support to distance function

### DIFF
--- a/packages/openrosa-xpath-evaluator/src/geo.js
+++ b/packages/openrosa-xpath-evaluator/src/geo.js
@@ -124,9 +124,14 @@ module.exports = {
     distance,
 };
 
-function asGeopoints(r) {
-    if (r.t === 'arr' && r.v.length > 1) {
-        return r.v.map(asString);
+function asGeopoints(...r) {
+    if (r.length > 1) {
+        return r.map(asString);
     }
-    return asString(r).split(';');
+
+    if (r[0].t === 'arr' && r[0].v.length > 1) {
+        return r[0].v.map(asString);
+    }
+
+    return asString(r[0]).split(';');
 }

--- a/packages/openrosa-xpath-evaluator/src/openrosa-extensions.js
+++ b/packages/openrosa-xpath-evaluator/src/openrosa-extensions.js
@@ -250,9 +250,9 @@ const openrosaXPathExtensions = function () {
         digest(msg, algo, encoding) {
             return XPR.string(digest(msg, algo, encoding));
         },
-        distance(r) {
+        distance(...r) {
             if (arguments.length === 0) throw TOO_FEW_ARGS;
-            return XPR.number(distance(asGeopoints(r)));
+            return XPR.number(distance(asGeopoints(...r)));
         },
         exp(r) {
             return XPR.number(Math.exp(asNumber(r)));

--- a/packages/openrosa-xpath-evaluator/test/integration/openrosa-xpath/geo.spec.js
+++ b/packages/openrosa-xpath-evaluator/test/integration/openrosa-xpath/geo.spec.js
@@ -86,6 +86,33 @@ describe('distance() and area() functions', () => {
         });
     });
 
+    describe('variadic distance', () => {
+        // https://www.mapdevelopers.com/area_finder.php?polygons=[[[[38.253094215699576%2C21.756382658677467]%2C[38.25021274773806%2C21.756382658677467]]]]
+        it('works with literal geopoint string arguments', () => {
+            assertNumberValue(
+                "distance('38.253094215699576 21.756382658677467 0 0', '38.25021274773806 21.756382658677467 0 0')",
+                320.76
+            );
+        });
+
+        it('works with nodeset reference arguments', () => {
+            const doc = initDoc(`
+                    <root id="root">
+                        <point1>38.253094215699576 21.756382658677467 0 0</point1>
+                        <point2>38.25021274773806 21.756382658677467 0 0</point2>
+                    </root>
+                `);
+
+            const node = doc.getElementById('root');
+            assertNumberValue(
+                node,
+                null,
+                'distance(/root/point1, /root/point2)',
+                320.76
+            );
+        });
+    });
+
     it('throws error when no parameters are provided', () => {
         assertThrow('area()');
         assertThrow('distance()');

--- a/packages/openrosa-xpath-evaluator/test/unit/geo.spec.js
+++ b/packages/openrosa-xpath-evaluator/test/unit/geo.spec.js
@@ -23,5 +23,12 @@ describe('geo', () => {
                 assert.deepEqual(asGeopoints(r), expected);
             });
         });
+
+        it(`should handle multiple arguments`, () => {
+            assert.deepEqual(
+                asGeopoints(wrapVal('1'), wrapVal('2'), wrapVal('3')),
+                ['1', '2', '3']
+            );
+        });
     });
 });


### PR DESCRIPTION
Closes https://github.com/enketo/enketo/issues/1325

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [x] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

In addition to the new tests, I tried [this example with the distance function](https://docs.google.com/spreadsheets/d/1gMOeQdq-DhXz4C1WvgPZ3hsdXDF2mDMYOKTbsRco4Hg/edit?gid=1068911091#gid=1068911091) in Enketo Core.

#### Why is this the best possible solution? Were any other approaches considered?

I didn't consider any alternatives. I'm not entirely sure whether this is an idiomatic way to handle variadic arguments in JS but I believe it to be straightforward and safe.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I think the main risk is that I may have gotten types subtly wrong in `asGeopoints`. There's enough testing that I think that would be unlikely but it could mean that some existing forms using `distance` break in possibly subtle ways.

#### Do we need any specific form for testing your changes? If so, please attach one.

https://docs.google.com/spreadsheets/d/1gMOeQdq-DhXz4C1WvgPZ3hsdXDF2mDMYOKTbsRco4Hg/edit?gid=1068911091#gid=1068911091
