### PR TITLE
Update Github actions

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -2,55 +2,45 @@ name: Build and push Enketo Express image to Docker Hub
 
 on:
     push:
-        # Don't waste time building every push: consider only tags, which are
-        # usually releases
         tags:
-            - '*'
+            - '[0-9]+.[0-9]+.[0-9]+'
+
+env:
+    REGISTRY: docker.io
+    IMAGE_NAME: ${{ github.repository }}
 
 jobs:
     docker-build-push:
         runs-on: ubuntu-latest
-        # The intent here is to check for "not prefixed". The reason to even have
-        # that intent in the first place is that there's no clear, proscribed way
-        # to get a substring (any substring), or do substring replacement in GitHub
-        # Actions syntax. So it is not possible to derive an unprefixed tag from
-        # a tag prefixed `enketo-express/`, which we had originally intended to do.
-        #
-        # So the workaround is "don't prefix enketo-express releases". The logic
-        # to check "not prefixed" is also not possible, for the same underlying
-        # reason: to check "not prefixed", we'd want to know if the tag name has
-        # a slash. We can't know that, because `github.ref` always has slashes,
-        # i.e. `refs/tags/unprefixed-tag-name`.
-        #
-        # So the next workaround is to enumerate all of the known prefixes we do
-        # not want to match.
-        #
-        # And then the syntax gets weird, because we're writing code, in the
-        # GitHub Actions DSL, within a string in YAML syntax. "Not" in GHA DSL
-        # is predictably expressed with `!`, which evidently has special meaning
-        # in YAML... which in turn causes a YAML syntax error at `,`.
-        #
-        # So then the GHA-DSL-code-in-YAML-string must be explicitly quoted. The
-        # actual GHA-DSL-code-in-YAML-string also contains quoted strings, and
-        # those quotes must not conflict. Double quotes also produces a syntax
-        # error, this time in the GHA DSL. Backslashes are ostensibly the correct
-        # mechanism to escape double quotes, but not single quotes: they are also
-        # a syntax error (only detectable by running the Action on GitHub).
-        #
-        # No, to escape single quotes in GHA-DSL-code-in-YAML-string, you must use
-        # double-single-quotes-within-single-quotes. So that is what we've got in
-        # this line here.
-        #
-        # That's not all. For VSCode users: if you need to edit this file, to save
-        # you must call the "File: Save without Formatting" command, lest it be
-        # reformatted with invalid double quotes.
-        if: '!startsWith(github.ref, ''refs/tags/openrosa-xpath-evaluator/'') && !startsWith(github.ref, ''refs/tags/enketo-transformer/'') && !startsWith(github.ref, ''refs/tags/enketo-core/'')'
+
         steps:
-            - uses: actions/checkout@v2
-            - uses: mr-smithers-excellent/docker-build-push@v2
+            - name: Check out repository
+              uses: actions/checkout@v4
+
+            - name: Log into registry ${{ env.REGISTRY }}
+              uses: docker/login-action@v3
               with:
-                  image: enketo/enketo-express
-                  registry: docker.io
-                  dockerfile: Dockerfile
+                  registry: ${{ env.REGISTRY }}
                   username: ${{ secrets.DOCKER_HUB_USERNAME }}
                   password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+            - name: Extract Docker metadata
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+            - name: Set up QEMU emulator for multi-arch images
+              uses: docker/setup-qemu-action@v3
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  platforms: 'linux/amd64,linux/arm64'

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -3,9 +3,7 @@ name: GHCR
 on: push
 
 env:
-    # Use docker.io for Docker Hub if empty
     REGISTRY: ghcr.io
-    # github.repository as <account>/<repo>
     IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -16,35 +14,36 @@ jobs:
             packages: write
 
         steps:
-            - name: Checkout repository
-              uses: actions/checkout@v2
+            - name: Check out repository
+              uses: actions/checkout@v4
 
             - name: Store version information
               run: git describe --tags > .tag.txt || git rev-parse --short HEAD > .tag.txt
 
-            # Login against a Docker registry
-            # https://github.com/docker/login-action
             - name: Log into registry ${{ env.REGISTRY }}
-              uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+              uses: docker/login-action@v3
               with:
                   registry: ${{ env.REGISTRY }}
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
-            # Extract metadata (tags, labels) for Docker
-            # https://github.com/docker/metadata-action
             - name: Extract Docker metadata
               id: meta
-              uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+              uses: docker/metadata-action@v5
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-            # Build and push Docker image with Buildx
-            # https://github.com/docker/build-push-action
+            - name: Set up QEMU emulator for multi-arch images
+              uses: docker/setup-qemu-action@v3
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
             - name: Build and push Docker image
-              uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+              uses: docker/build-push-action@v6
               with:
                   context: .
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
+                  platforms: 'linux/amd64,linux/arm64'


### PR DESCRIPTION
- Consistently pins major version only for Github actions, upgrades to latest
- Builds multi-arch Docker images
- Simplifies how the Docker Hub action runs only on EE release tags

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above

#### What else has been done to verify that this works as intended?
I tagged releases on my branch and verified that the Docker Hub action only runs on unprefixed tags.

I verified that the GHCR image has multiple architectures: https://github.com/lognaturel/enketo/pkgs/container/enketo/243102326?tag=gh-actions



#### Why is this the best possible solution? Were any other approaches considered?

It brings some internal consistency and brings things up to date.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Users will get to use images for their native architecture.

I didn't actually try publishing to Docker Hub so there's a risk that won't work as expected. It matches GHCR, though, so I think risk is low.

#### Do we need any specific form for testing your changes? If so, please attach one.
