### PR TITLE
Docker Hub image name should be enketo-express

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -7,7 +7,7 @@ on:
 
 env:
     REGISTRY: docker.io
-    IMAGE_NAME: ${{ github.repository }}
+    IMAGE_NAME: enketo/enketo-express
 
 jobs:
     docker-build-push:

--- a/packages/enketo-express/CHANGELOG.md
+++ b/packages/enketo-express/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 7.3.1 - 2024-07-15
+
+-   Publish to DockerHub as enketo-express (not enketo like GHCR)
+
 ## 7.3.0 - 2024-07-12
 
 -   If redis is configured with a URL, use the url as-is (#1297)

--- a/packages/enketo-express/package.json
+++ b/packages/enketo-express/package.json
@@ -2,7 +2,7 @@
     "name": "enketo-express",
     "description": "Webforms evolved.",
     "homepage": "https://enketo.org",
-    "version": "7.3.0",
+    "version": "7.3.1",
     "main": "./app.js",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The 7.3.0 run of the Docker Hub action failed because it tried to upload to enketo/enketo instead of https://hub.docker.com/r/enketo/enketo-express

~This led me to notice that we accidentally changed the image name published to GHCR in the monorepo migration. I think we should change it back to `enketo-express` for consistency. This is technically a breaking change in the sense that downstream users may need to make a change. We've historically been somewhat loose about how semver applies to EE because it's an application rather than a library. I propose we release this as a patch version just to retrigger CI. I think anyone who relies on the images likely follows this repo to see when releases are made.~ Thinking about this more, I think it would leave users in a potentially confusing state that keeps them from upgrading. It's an annoying mistake. I think we just live with it for now.

Ideally we would build the images once and upload to both target registries. That means we'd want to do some filtering because we only want to publish to Docker Hub on release. I don't have more time to spend on this now, though, and Github actions makes this annoyingly difficult.