### PR TITLE
Fixed translation cache of element with i18nNumber

### DIFF
--- a/packages/enketo-express/public/js/src/module/translator.js
+++ b/packages/enketo-express/public/js/src/module/translator.js
@@ -87,34 +87,44 @@ const localize = (container, lng) => {
         })
         .then(() => {
             list.forEach((el) => {
-                const key = el.dataset.i18n;
+                let key = el.dataset.i18n;
+                // translation key for element with i18nNumber is i18n-i18nNumber
+                if (el.dataset.i18nNumber) {
+                    key = `${key}-${el.dataset.i18nNumber}`;
+                }
                 if (key) {
-                    if (!cache[key]) {
-                        let options = {};
-                        // quick hack for __icon__ replacement
-                        if (el.dataset.i18nIcon) {
-                            options = {
-                                icon: `<span class="icon ${el.dataset.i18nIcon}"> </span>`,
-                                interpolation: { escapeValue: false },
-                            };
-                        }
-                        if (el.dataset.i18nNumber) {
-                            options = {
-                                number: el.dataset.i18nNumber,
-                            };
-                        }
-                        cache[key] = t(key, options);
+                    let options = {};
+                    // quick hack for __icon__ replacement
+                    if (el.dataset.i18nIcon) {
+                        options = {
+                            icon: `<span class="icon ${el.dataset.i18nIcon}"> </span>`,
+                            interpolation: { escapeValue: false },
+                        };
                     }
+                    if (el.dataset.i18nNumber) {
+                        options = {
+                            number: el.dataset.i18nNumber,
+                        };
+                    }
+
+                    // Insert cache only if the translation is new
+                    if (!cache[key]) {
+                        cache[key] = t(el.dataset.i18n, options);
+                    }
+
                     // This assumes that if the element has a placeholder, that's the thing that
                     // needs to be localized, since placeholders are only used on form controls,
                     // and the textContent of a form control is never translatable.
+                    const translationCache = cache[key];
                     if (el.placeholder) {
-                        el.placeholder = cache[key];
+                        el.placeholder = translationCache;
                     } else if (el.dataset.i18nIcon) {
                         el.textContent = '';
-                        el.append(range.createContextualFragment(cache[key]));
+                        el.append(
+                            range.createContextualFragment(translationCache)
+                        );
                     } else {
-                        el.textContent = cache[key];
+                        el.textContent = translationCache;
                     }
                 }
             });

--- a/packages/enketo-express/public/js/src/module/translator.js
+++ b/packages/enketo-express/public/js/src/module/translator.js
@@ -93,22 +93,21 @@ const localize = (container, lng) => {
                     key = `${key}-${el.dataset.i18nNumber}`;
                 }
                 if (key) {
-                    let options = {};
-                    // quick hack for __icon__ replacement
-                    if (el.dataset.i18nIcon) {
-                        options = {
-                            icon: `<span class="icon ${el.dataset.i18nIcon}"> </span>`,
-                            interpolation: { escapeValue: false },
-                        };
-                    }
-                    if (el.dataset.i18nNumber) {
-                        options = {
-                            number: el.dataset.i18nNumber,
-                        };
-                    }
-
                     // Insert cache only if the translation is new
                     if (!cache[key]) {
+                        let options = {};
+                        // quick hack for __icon__ replacement
+                        if (el.dataset.i18nIcon) {
+                            options = {
+                                icon: `<span class="icon ${el.dataset.i18nIcon}"> </span>`,
+                                interpolation: { escapeValue: false },
+                            };
+                        }
+                        if (el.dataset.i18nNumber) {
+                            options = {
+                                number: el.dataset.i18nNumber,
+                            };
+                        }
                         cache[key] = t(el.dataset.i18n, options);
                     }
 


### PR DESCRIPTION
Closes #1337 

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [x] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?
Just found the problem in editing submission. I think that is sufficent in this case.

#### Why is this the best possible solution? Were any other approaches considered?
The usage of combination of i18n and i18nNumber as key is the fast way to cache the result.

Yes, other solution could be removing the usage of i18n (and i18nNumber) in selectpicker widget but that will render the cache useless in this case.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
None.

#### Do we need any specific form for testing your changes? If so, please attach one.
No, just usual multiselect in a repeating group.
