### PR TITLE
Hide date widget fake input when rendering pdf

### DIFF
--- a/packages/enketo-core/src/widget/text-print/text-print.js
+++ b/packages/enketo-core/src/widget/text-print/text-print.js
@@ -36,6 +36,15 @@ class TextPrintWidget extends Widget {
             this.element.after(printElement);
             this.element.classList.add('print-hide');
 
+            // If previous element is a fake input in date widget, hide it as well
+            const previousElement = this.element.previousElementSibling;
+            if (
+                previousElement !== null &&
+                previousElement.classList.contains('date')
+            ) {
+                previousElement.classList.add('print-hide');
+            }
+
             this.widget = this.element.parentElement.querySelector(
                 `.${className}`
             );


### PR DESCRIPTION
Closes #1340 

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above : Print PDF

#### What else has been done to verify that this works as intended?
Get PDF and check the PDF result.

#### Why is this the best possible solution? Were any other approaches considered?
The minimal and fast way to achieve the result.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
None.

#### Do we need any specific form for testing your changes? If so, please attach one.
No. Just usual form contains date item.
