### PR TITLE
Significant performance improvement using XPath browser native evaluation

### DIFF
--- a/packages/enketo-core/src/js/calculate.js
+++ b/packages/enketo-core/src/js/calculate.js
@@ -344,7 +344,8 @@ export default {
                       newExpr,
                       'string',
                       props.name,
-                      props.index
+                      props.index,
+                      true // Try native XPath evaluation
                   )
                 : '';
 


### PR DESCRIPTION
I have been discussing very slow XPath evaluation with @lognaturel via ODK support and I believe I have pinpointed the problem to this call to `calculate()` which never tries native evaluation. In my case, native vs. JS/slow produced the same result, so my understanding is that native should've been attempted and would've worked, and we already have protections like the `OPENROSA` regex to avoid calling the browser with XPath it won't understand. Are there any side effects to this change?

![image](https://github.com/user-attachments/assets/66a3cae9-8aae-44c9-a85f-e68cbf30a969)

Closes #

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.
