### PR TITLE
Fix `bootstrap-datepicker` CSS file import

### DIFF
--- a/packages/enketo-core/src/widget/date/datepicker-extended.scss
+++ b/packages/enketo-core/src/widget/date/datepicker-extended.scss
@@ -1,4 +1,4 @@
-@import '/packages/enketo-core/node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker.min';
+@import '/packages/enketo-core/node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker';
 
 /** fixes by martijn **/
 


### PR DESCRIPTION
Closes #14 .

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above

#### What else has been done to verify that this works as intended?

Consuming `enketo-core` v8.3.0 in Vite for both development and production works.

#### Why is this the best possible solution? Were any other approaches considered?

An alternative is "plain `@import`" the minified `bootstrap-datepicker.min.css`, note the extension, but letting the compiler of choice handle the compilation sounds appropriate.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

If your compiler is not minifying the SCSS output then we're including a slightly larger CSS module.

#### Do we need any specific form for testing your changes? If so, please attach one.

No, it shouldn't have an effect on any existing form definition.
