### PR TITLE
redis-repl: require() without filesystem expectations

### DIFF
--- a/packages/enketo-express/tools/redis-repl
+++ b/packages/enketo-express/tools/redis-repl
@@ -3,7 +3,7 @@
 process.env.NODE_ENV = 'development';
 
 const { REPLServer } = require('repl');
-const redisVersion = require('../node_modules/redis/package.json').version;
+const redisVersion = require('redis/package.json').version;
 const { cacheClient, mainClient } = require('../app/lib/db');
 
 const log = (...args) => console.error('[redis-repl]', ...args);


### PR DESCRIPTION
Fixes loading of the redis module version when it is not at a specific relative path.