### PR TITLE
ci/ghcr: build less

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,6 +1,10 @@
 name: GHCR
 
-on: push
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    tags:
 
 env:
     REGISTRY: ghcr.io


### PR DESCRIPTION
Instead of building images for GitHub Container Registry (GHCR) on every push, only build:

* pushes to master
* any tag
* when explicitly requested through the UI

Ref: https://github.com/enketo/enketo/issues/1334

