### PR TITLE
eslint: use cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ Thumbs.db
 # 5.1. Tooling - development
 # -----------------------------------------------------------------------------
 
+/.eslintcache
 /.grunt/
 /examples/*/.grunt/
 /packages/*/.grunt/

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "build": "yarn workspaces run build",
-        "lint": "eslint .",
+        "lint": "eslint --cache .",
         "test": "yarn workspaces run test",
         "postinstall": "yarn build"
     },


### PR DESCRIPTION
On my machine this reduces subsequent calls to `yarn eslint` from ~45 seconds to ~5 seconds.

### `main`

```sh
$ time (yarn lint >/dev/null 2>&1); time (yarn lint >/dev/null 2>&1)

real	0m47.749s
user	1m8.716s
sys	0m2.555s

real	0m56.520s
user	1m17.087s
sys	0m3.006s
```

### this PR

```sh
$ time (yarn lint >/dev/null 2>&1); time (yarn lint >/dev/null 2>&1)

real	0m38.469s
user	1m1.172s
sys	0m2.492s

real	0m3.629s
user	0m4.223s
sys	0m0.541s
```