### PR TITLE
eslint: hide warnings in output

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "build": "yarn workspaces run build",
-        "lint": "eslint .",
+        "lint": "eslint --quiet .",
         "test": "yarn workspaces run test",
         "postinstall": "yarn build"
     },


### PR DESCRIPTION
* currently `yarn eslint` shows 2,521 warnings
* these warnings do not break the build, but
* they make it very hard to find errors in the output
