### PR TITLE
enketo-core: fix getter-only number-input properties

### DIFF
--- a/packages/enketo-core/src/widget/number-input/decimal-input.js
+++ b/packages/enketo-core/src/widget/number-input/decimal-input.js
@@ -97,7 +97,9 @@ export default class DecimalInput extends NumberInput {
         super.globalReset(form, rootElement);
     }
 
-    static selector = '.question input[type="number"][data-type-xml="decimal"]';
+    static get selector() {
+        return '.question input[type="number"][data-type-xml="decimal"]';
+    }
 
     static get decimalCharacters() {
         return getDecimalCharacters(this.languages);

--- a/packages/enketo-core/src/widget/number-input/integer-input.js
+++ b/packages/enketo-core/src/widget/number-input/integer-input.js
@@ -43,13 +43,17 @@ export default class IntegerInput extends NumberInput {
         super.globalReset(form, rootElement);
     }
 
-    static selector = '.question input[type="number"][data-type-xml="int"]';
+    static get selector() {
+        return '.question input[type="number"][data-type-xml="int"]';
+    }
 
     static get validCharacters() {
         return getValidCharacters(this.languages);
     }
 
-    static pattern = /^-?[0-9]+$/;
+    static get pattern() {
+        return /^-?[0-9]+$/;
+    }
 
     get value() {
         return super.value;


### PR DESCRIPTION
### Context

Before this fix, the browser console error shows info such as: `TypeError: Cannot set property selector of NumberInput which has only a getter`. See also https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Getter_only

### I have verified this PR works with

-   [x] Enketo-core web submission within the NEMO app
-   [ ] I have not set up testing elsewhere :(

### What else has been done to verify that this works as intended?

Browser console error is now fixed, and basic Enketo forms are no longer broken within NEMO on the latest version of enketo-core.

### Why is this the best possible solution? Were any other approaches considered?

It's possible this fix is specific to enketo-core inside of a Rails app, and may not affect the larger Enketo ecosystem, though I'm honestly not sure why it isn't causing more problems given that the code has been like this for about 1 year.

See original change that led to this situation: https://github.com/enketo/enketo/commit/bef4acfc30d392e5db5444035f19195d792be62b#diff-cdaa0aebb64f07271a05ff8257fbc534615791d99dafa5483ee9b0e1c998d4ccR4

### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It's possible that things were working despite this issue, and they may break now that it's fixed; or it's possible that this isn't actually an issue for most people and this change won't affect the average user.

### Do we need any specific form for testing your changes? If so, please attach one.

No, this error occurred with any form that used any kind of text field, even plain text.