### PR TITLE
express/locales/es: fix translation keys

### DIFF
--- a/packages/enketo-express/locales/src/es/translation.json
+++ b/packages/enketo-express/locales/src/es/translation.json
@@ -100,7 +100,7 @@
             "redirectmsg": "Será automáticamente redirigido después del envío"
         },
         "submissionerror": {
-            "authrequiredmsg": "Es necesaria la autenticación. Por favor autentifíquese __aquí__ en una pestaña diferente del navegador y pruebe de nuevo.",
+            "authrequiredmsg": "Es necesaria la autenticación. Por favor autentifíquese __here__ en una pestaña diferente del navegador y pruebe de nuevo.",
             "fnfmsg": [
                 "No hemos podido recuperar los siguientes archivos de tipo multimedia __failedFiles__ . El envío siguió su curso sin estos archivos y fue un éxito.",
                 "Por favor contáctese con __supportEmail__ para reportar un fallo (bug) y si es posible explicar como se produjo dicho fallo para que sea reproducido y nos permita corregirlo."
@@ -125,7 +125,7 @@
             "msg": "Formulario correcto!"
         },
         "valuehasspaces": {
-            "multiple": "Pregunta de Selección múltiple contiene un valor ilegal \"__valor__\" que contiene un espacio."
+            "multiple": "Pregunta de Selección múltiple contiene un valor ilegal \"__value__\" que contiene un espacio."
         },
         "xpatherror": {
             "heading": "Error en la fórmula",


### PR DESCRIPTION
Some translation value keys were translated into Spanish.  This commit translates them back to English so that they can be correctly substituted.

Closes #1370

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above

#### What else has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

No other approaches considered.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This may introduce incorrect translations, or not fix the value interpolations.

#### Do we need any specific form for testing your changes? If so, please attach one.

No.