### PR TITLE
express/README: fix Transifex link

### DIFF
--- a/packages/enketo-express/README.md
+++ b/packages/enketo-express/README.md
@@ -112,7 +112,7 @@ Enketo Express includes a number of customization and extension points. See [tut
 
 The user interface was translated by: Oleg Zhyliak (Ukrainian), Karol Kozyra (Swedish), Badisches Rotes Kreuz (German), Serkan Tümbaş (Turkish), Hélène Martin (French), Gurjot Sidhu (Hindi, Panjabi), "Abcmen" (Turkish), Otto Saldadze, Makhare Atchaidze, David Sichinava, Elene Ergeshidze (Georgian), Nancy Shapsough (Arabic), Noel O'Boyle (French), Miguel Moreno (Spanish), Tortue Torche (French), Bekim Kajtazi (Albanian), Marc Kreidler (German), Darío Hereñú (Spanish), Viktor S. (Russian), Alexander Torrado Leon (Spanish), Peter Smith (Portugese, Spanish), Przemysław Gumułka (Polish), Niklas Ljungkvist, Sid Patel (Swedish), Katri Jalava (Finnish), Francesc Garre (Spanish), Sounay Phothisane (Lao), Linxin Guo (Chinese), Emmanuel Jean, Renaud Gaudin (French), Trần Quý Phi (Vietnamese), Reza Doosti, Hossein Azad, Davood Mottalee (Persian), Tomas Skripcak (Slovak, Czech, German), Daniela Baldova (Czech), Robert Michael Lundin (Norwegian), Margaret Ndisha, Charles Mutisya (Swahili), Panzero Mauro (Italian), Gabriel Kreindler (Romanian), Jason Reeder, Omar Nazar, Sara Sameer, David Gessel (Arabic), Tino Kreutzer (German), Wasilis Mandratzis-Walz (German, Greek), Luis Molina (Spanish), Martijn van de Rijdt (Dutch).
 
-_Join the project on [Transifex](https://www.transifex.com/projects/p/enketo-express/) to contribute!_
+_Join the project on [Transifex](https://explore.transifex.com/enketo/enketo-express/) to contribute!_
 
 ### Funding
 


### PR DESCRIPTION
Current link (https://www.transifex.com/projects/p/enketo-express/) does not work.

```http
$ curl --head https://www.transifex.com/projects/p/enketo-express/
HTTP/2 301 
date: Fri, 29 Nov 2024 08:39:09 GMT
content-type: text/html
content-length: 162
location: https://explore.transifex.com
server: nginx
strict-transport-security: max-age=31536000; includeSubDomains
```

Closes #

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above

#### What else has been done to verify that this works as intended?

CI.

#### Why is this the best possible solution? Were any other approaches considered?

No.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Helps them get to the translation platform.

#### Do we need any specific form for testing your changes? If so, please attach one.

No.