### PR TITLE
enketo-express: fix handling for unsupported locales

### DIFF
--- a/packages/enketo-express/config/express.js
+++ b/packages/enketo-express/config/express.js
@@ -40,7 +40,7 @@ i18next
     .use(I18nextBackend)
     .init({
         // debug: true, // DEBUG
-        whitelist: app.get('languages supported'),
+        supportedLngs: app.get('languages supported'),
         fallbackLng: 'en',
         joinArrays: '\n',
         backend: {

--- a/packages/enketo-express/public/js/src/module/translator.js
+++ b/packages/enketo-express/public/js/src/module/translator.js
@@ -35,7 +35,7 @@ const initialize = new Promise((resolve, reject) => {
         .use(htmlParagraphsPostProcessor)
         .init(
             {
-                whitelist: settings.languagesSupported,
+                supportedLngs: settings.languagesSupported,
                 fallbackLng: 'en',
                 joinArrays: '\n',
                 backend: {


### PR DESCRIPTION
In `i18next` v21, the `whitelist` config option was renamed to `supportedLngs`.

`enketo-express` `i18next` dependency was updated from v20 to v24 in December 2024 in commit 0ac29cbe50de33cd5e0732aaec498817b5c31fa6.

See: https://www.i18next.com/misc/migration-guide#v20.x.x-to-v21.0.0

Closes #1383

#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [x] None of the above

#### What else has been done to verify that this works as intended?

Ran enketo-express locally and tested with a weird locale.

#### Why is this the best possible solution? Were any other approaches considered?

It seems straightforward, and inline with `i18next` migration documentation.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should fix a bug for them.

#### Do we need any specific form for testing your changes? If so, please attach one.

Should be fixed (and previously broken) for all forms.