### PR TITLE
Build on main, not master

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -3,7 +3,7 @@ name: GHCR
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main]
     tags:
 
 env:


### PR DESCRIPTION
Enketo staging server was not updating because it builds on main. https://github.com/enketo/enketo/pull/1361 broke this by switching builds to master.