### PR TITLE
Exclude maps from swipe action DEV-181

### DIFF
--- a/packages/enketo-core/src/js/page.js
+++ b/packages/enketo-core/src/js/page.js
@@ -182,6 +182,8 @@ export default {
             allowPageScroll: 'vertical',
             threshold: 250,
             preventDefaultEvents: false,
+            excludedElements:
+                $.fn.swipe.defaults.excludedElements + ', .map-canvas-wrapper',
             swipeLeft() {
                 that.$btnNext.click();
             },

--- a/packages/enketo-core/src/js/page.js
+++ b/packages/enketo-core/src/js/page.js
@@ -182,8 +182,7 @@ export default {
             allowPageScroll: 'vertical',
             threshold: 250,
             preventDefaultEvents: false,
-            excludedElements:
-                $.fn.swipe.defaults.excludedElements + ', .map-canvas-wrapper',
+            excludedElements: `${$.fn.swipe.defaults.excludedElements}, .map-canvas-wrapper`,
             swipeLeft() {
                 that.$btnNext.click();
             },


### PR DESCRIPTION
Closes #1359 

#### I have verified this PR works with

-   [x] Online form submission
-   [x] Offline form submission
-   [x] Saving offline drafts
-   [x] Loading offline drafts
-   [x] Editing submissions
-   [x] Form preview
-   [ ] None of the above

#### Why is this the best possible solution? Were any other approaches considered?
This is the simplest and recommended solution. 
The exclusion of elements is a deature of the lib:
https://www.npmjs.com/package/jquery-touchswipe/v/1.6.7
http://labs.rampinteractive.co.uk/touchSwipe/docs/tutorial-Excluded_children.html

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No risk of regression.
This PR only affects swipe actions, excluding an specific class used for maps, therefore avoiding triggering the swipe actions when interacting to maps.

#### Do we need any specific form for testing your changes? If so, please attach one.
It can be tested with the form attached to issue #1359: [XLSForm_map_panning_bug.xlsx](https://github.com/user-attachments/files/17567485/XLSForm_map_panning_bug.xlsx)
Also in XML format (needs to be renamed from .txt to .xml):  [XLSForm_map_panning_bug.xml.txt](https://github.com/user-attachments/files/19794700/XLSForm_map_panning_bug.xml.txt)

