### PR TITLE
fix(encryption): UTF-8 encode submission xml when creating MD5 hash DEV-921

### DIFF
--- a/packages/enketo-express/public/js/src/module/encryptor.js
+++ b/packages/enketo-express/public/js/src/module/encryptor.js
@@ -173,15 +173,21 @@ function _rsaEncrypt(byteString, publicKey) {
 
 function _md5Digest(byteString) {
     const md = forge.md.md5.create();
-    md.update(byteString, 'utf8');
+    md.update(byteString);
 
+    return md.digest();
+}
+
+function _md5DigestUtf8(text) {
+    const md = forge.md.md5.create();
+    md.update(forge.util.encodeUtf8(text));
     return md.digest();
 }
 
 function _getBase64EncryptedElementSignature(elements, publicKey) {
     // ODK Collect code also adds a newline character **at the end**!
     const elementsStr = `${elements.join('\n')}\n`;
-    const messageDigest = _md5Digest(elementsStr).getBytes();
+    const messageDigest = _md5DigestUtf8(elementsStr).getBytes();
 
     return _rsaEncrypt(messageDigest, publicKey);
 }
@@ -233,7 +239,7 @@ function _encryptSubmissionXml(xmlStr, symmetricKey, seed) {
         seed
     );
     submissionXmlEnc.name = 'submission.xml.enc';
-    submissionXmlEnc.md5 = _md5Digest(xmlStr).toHex();
+    submissionXmlEnc.md5 = _md5DigestUtf8(xmlStr).toHex();
 
     return submissionXmlEnc;
 }

--- a/packages/enketo-express/public/js/src/module/encryptor.js
+++ b/packages/enketo-express/public/js/src/module/encryptor.js
@@ -178,16 +178,10 @@ function _md5Digest(byteString) {
     return md.digest();
 }
 
-function _md5DigestUtf8(text) {
-    const md = forge.md.md5.create();
-    md.update(forge.util.encodeUtf8(text));
-    return md.digest();
-}
-
 function _getBase64EncryptedElementSignature(elements, publicKey) {
     // ODK Collect code also adds a newline character **at the end**!
     const elementsStr = `${elements.join('\n')}\n`;
-    const messageDigest = _md5DigestUtf8(elementsStr).getBytes();
+    const messageDigest = _md5Digest(forge.util.encodeUtf8(elementsStr)).getBytes();
 
     return _rsaEncrypt(messageDigest, publicKey);
 }
@@ -239,7 +233,7 @@ function _encryptSubmissionXml(xmlStr, symmetricKey, seed) {
         seed
     );
     submissionXmlEnc.name = 'submission.xml.enc';
-    submissionXmlEnc.md5 = _md5DigestUtf8(xmlStr).toHex();
+    submissionXmlEnc.md5 = _md5Digest(forge.util.encodeUtf8(xmlStr)).toHex();
 
     return submissionXmlEnc;
 }
@@ -282,7 +276,8 @@ function _encryptContent(content, symmetricKey, seed) {
 
 function Seed(instanceId, symmetricKey) {
     // iv is the 16-byte md5 hash of the instanceID and the symmetric key
-    const messageDigest = _md5Digest(instanceId + symmetricKey).getBytes();
+    const byteString = forge.util.encodeUtf8(instanceId) + symmetricKey;
+    const messageDigest = _md5Digest(byteString).getBytes();
     const ivSeedArray = messageDigest
         .split('')
         .map((item) => item.charCodeAt(0));

--- a/packages/enketo-express/public/js/src/module/encryptor.js
+++ b/packages/enketo-express/public/js/src/module/encryptor.js
@@ -276,8 +276,10 @@ function _encryptContent(content, symmetricKey, seed) {
 
 function Seed(instanceId, symmetricKey) {
     // iv is the 16-byte md5 hash of the instanceID and the symmetric key
-    const byteString = forge.util.encodeUtf8(instanceId) + symmetricKey;
-    const messageDigest = _md5Digest(byteString).getBytes();
+    const md = forge.md.md5.create();
+    md.update(forge.util.encodeUtf8(instanceId));
+    md.update(symmetricKey);
+    const messageDigest = md.digest().getBytes();
     const ivSeedArray = messageDigest
         .split('')
         .map((item) => item.charCodeAt(0));

--- a/packages/enketo-express/public/js/src/module/encryptor.js
+++ b/packages/enketo-express/public/js/src/module/encryptor.js
@@ -171,9 +171,12 @@ function _rsaEncrypt(byteString, publicKey) {
     return forge.util.encode64(encrypted);
 }
 
-function _md5Digest(byteString) {
+function _md5Digest(...byteString) {
     const md = forge.md.md5.create();
-    md.update(byteString);
+
+    byteString.forEach((byte) => {
+        md.update(byte);
+    });
 
     return md.digest();
 }
@@ -276,10 +279,7 @@ function _encryptContent(content, symmetricKey, seed) {
 
 function Seed(instanceId, symmetricKey) {
     // iv is the 16-byte md5 hash of the instanceID and the symmetric key
-    const md = forge.md.md5.create();
-    md.update(forge.util.encodeUtf8(instanceId));
-    md.update(symmetricKey);
-    const messageDigest = md.digest().getBytes();
+    const messageDigest = _md5Digest(forge.util.encodeUtf8(instanceId), symmetricKey).getBytes();
     const ivSeedArray = messageDigest
         .split('')
         .map((item) => item.charCodeAt(0));

--- a/packages/enketo-express/public/js/src/module/encryptor.js
+++ b/packages/enketo-express/public/js/src/module/encryptor.js
@@ -173,7 +173,7 @@ function _rsaEncrypt(byteString, publicKey) {
 
 function _md5Digest(byteString) {
     const md = forge.md.md5.create();
-    md.update(byteString);
+    md.update(byteString, 'utf8');
 
     return md.digest();
 }

--- a/packages/enketo-express/public/js/src/module/encryptor.js
+++ b/packages/enketo-express/public/js/src/module/encryptor.js
@@ -184,7 +184,9 @@ function _md5Digest(...byteString) {
 function _getBase64EncryptedElementSignature(elements, publicKey) {
     // ODK Collect code also adds a newline character **at the end**!
     const elementsStr = `${elements.join('\n')}\n`;
-    const messageDigest = _md5Digest(forge.util.encodeUtf8(elementsStr)).getBytes();
+    const messageDigest = _md5Digest(
+        forge.util.encodeUtf8(elementsStr)
+    ).getBytes();
 
     return _rsaEncrypt(messageDigest, publicKey);
 }
@@ -279,7 +281,10 @@ function _encryptContent(content, symmetricKey, seed) {
 
 function Seed(instanceId, symmetricKey) {
     // iv is the 16-byte md5 hash of the instanceID and the symmetric key
-    const messageDigest = _md5Digest(forge.util.encodeUtf8(instanceId), symmetricKey).getBytes();
+    const messageDigest = _md5Digest(
+        forge.util.encodeUtf8(instanceId),
+        symmetricKey
+    ).getBytes();
     const ivSeedArray = messageDigest
         .split('')
         .map((item) => item.charCodeAt(0));

--- a/packages/enketo-express/public/js/src/module/encryptor.js
+++ b/packages/enketo-express/public/js/src/module/encryptor.js
@@ -174,8 +174,8 @@ function _rsaEncrypt(byteString, publicKey) {
 function _md5Digest(...byteString) {
     const md = forge.md.md5.create();
 
-    byteString.forEach((byte) => {
-        md.update(byte);
+    byteString.forEach((string) => {
+        md.update(string);
     });
 
     return md.digest();

--- a/packages/enketo-express/test/client/encryptor.spec.js
+++ b/packages/enketo-express/test/client/encryptor.spec.js
@@ -259,7 +259,7 @@ describe('Encryptor', () => {
                 .catch(done);
         });
 
-        it('converts submission XML with non-ASCII characters into UTF-8 encoding before MD5 hashing', (done) => {
+        it('encodes submission XML with non-ASCII characters into UTF-8 before MD5 hashing', (done) => {
             const record = {
                 xml: '<root>café résumé naïve</root>',
                 instanceId: '1a2b',

--- a/packages/enketo-express/test/client/encryptor.spec.js
+++ b/packages/enketo-express/test/client/encryptor.spec.js
@@ -99,7 +99,7 @@ describe('Encryptor', () => {
             ]);
         });
 
-        it('correctly generates seed for instanceId with non-ASCII characters', () => {
+        it('encodes instanceId with non-ASCII characters into UTF-8 before MD5 hashing', () => {
             const seed = new encryptor.Seed(
                 'abcdefgé',
                 'ÛdGÆF§Dq3V*px!>XRÿ÷ëp7§'
@@ -259,7 +259,7 @@ describe('Encryptor', () => {
                 .catch(done);
         });
 
-        it('generates a correct MD5 hash for a submission with non-ASCII characters', (done) => {
+        it('converts submission XML with non-ASCII characters into UTF-8 encoding before MD5 hashing', (done) => {
             const record = {
                 xml: '<root>café résumé naïve</root>',
                 instanceId: '1a2b',
@@ -271,7 +271,6 @@ describe('Encryptor', () => {
                     expect(encryptedRecord.files[0].md5).to.equal(
                         '2ba225a35204382b2195ac4fcd60a3f9'
                     );
-
                     done();
                 })
                 .catch(done);

--- a/packages/enketo-express/test/client/encryptor.spec.js
+++ b/packages/enketo-express/test/client/encryptor.spec.js
@@ -243,7 +243,7 @@ describe('Encryptor', () => {
                 .catch(done);
         });
 
-        it('generates a correct submission manifest for a submission with non-ASCII characters', (done) => {
+        it('generates a correct MD5 hash for a submission with non-ASCII characters', (done) => {
             const record = {
                 xml: '<root>café résumé naïve</root>',
                 instanceId: '1a2b',
@@ -252,78 +252,9 @@ describe('Encryptor', () => {
             encryptor
                 .encryptRecord(form, record)
                 .then((encryptedRecord) => {
-                    const doc = new DOMParser().parseFromString(
-                        encryptedRecord.xml,
-                        'text/xml'
+                    expect(encryptedRecord.files[0].md5).to.equal(
+                        '2ba225a35204382b2195ac4fcd60a3f9'
                     );
-                    expect(doc.querySelectorAll('data').length).to.equal(1);
-                    expect(doc.querySelector('data').namespaceURI).to.equal(
-                        SUBMISSION_NS
-                    );
-                    expect(
-                        doc.querySelector('data').getAttribute('id')
-                    ).to.equal('abc');
-                    expect(
-                        doc.querySelector('data').getAttribute('version')
-                    ).to.equal('2');
-                    expect(
-                        doc.querySelector('data').getAttribute('encrypted')
-                    ).to.equal('yes');
-                    expect(
-                        doc.querySelectorAll('data > base64EncryptedKey').length
-                    ).to.equal(1);
-                    expect(
-                        doc.querySelector('data > base64EncryptedKey')
-                            .textContent
-                    ).to.match(/.+==$/);
-                    expect(
-                        doc.querySelector('data > base64EncryptedKey')
-                            .namespaceURI
-                    ).to.equal(SUBMISSION_NS);
-                    expect(doc.querySelectorAll('data > meta').length).to.equal(
-                        1
-                    );
-                    expect(
-                        doc.querySelector('data > meta').namespaceURI
-                    ).to.equal(XFORMS_NS);
-                    expect(
-                        doc.querySelectorAll('data > meta > instanceID').length
-                    ).to.equal(1);
-                    expect(
-                        doc.querySelector('data > meta > instanceID')
-                            .textContent
-                    ).to.equal('1a2b');
-                    expect(
-                        doc.querySelector('data > meta > instanceID')
-                            .namespaceURI
-                    ).to.equal(XFORMS_NS);
-                    expect(
-                        doc.querySelectorAll(
-                            'data > base64EncryptedElementSignature'
-                        ).length
-                    ).to.equal(1);
-                    expect(
-                        doc.querySelector(
-                            'data > base64EncryptedElementSignature'
-                        ).textContent
-                    ).to.match(/.+==$/);
-                    expect(
-                        doc.querySelector(
-                            'data > base64EncryptedElementSignature'
-                        ).namespaceURI
-                    ).to.equal(SUBMISSION_NS);
-                    expect(
-                        doc.querySelector('data > encryptedXmlFile').textContent
-                    ).to.equal('submission.xml.enc');
-                    expect(
-                        doc.querySelector('data >encryptedXmlFile').namespaceURI
-                    ).to.equal(SUBMISSION_NS);
-                    // only used by Enketo temporarily and then removed:
-                    expect(
-                        doc
-                            .querySelector('data >encryptedXmlFile')
-                            .getAttribute('type')
-                    ).to.equal('file');
 
                     done();
                 })

--- a/packages/enketo-express/test/client/encryptor.spec.js
+++ b/packages/enketo-express/test/client/encryptor.spec.js
@@ -314,17 +314,17 @@ describe('Encryptor', () => {
             sandbox.stub(forge.pki, 'publicKeyFromPem').returns(mockPublicKey);
 
             const encryptedSymmetricKey = mockPublicKey.encrypt(mockBytes);
+            const submissionXMLMD5 = forge.md.md5
+                .create()
+                .update(forge.util.encodeUtf8(record.xml))
+                .digest()
+                .toHex();
             const expectedElements = [
                 form.id,
                 form.version,
                 forge.util.encode64(encryptedSymmetricKey),
                 record.instanceId,
-                'submission.xml::' +
-                    forge.md.md5
-                        .create()
-                        .update(forge.util.encodeUtf8(record.xml))
-                        .digest()
-                        .toHex(),
+                `submission.xml::${submissionXMLMD5}`,
             ];
             const elementsStr = `${expectedElements.join('\n')}\n`;
             const md = forge.md.md5.create();

--- a/packages/enketo-express/test/client/encryptor.spec.js
+++ b/packages/enketo-express/test/client/encryptor.spec.js
@@ -98,6 +98,22 @@ describe('Encryptor', () => {
                 193, 231,
             ]);
         });
+
+        it('correctly generates seed for instanceId with non-ASCII characters', () => {
+            const seed = new encryptor.Seed(
+                'abcdefgé',
+                'ÛdGÆF§Dq3V*px!>XRÿ÷ëp7§'
+            );
+            const first = seed
+                .getIncrementedSeedByteString()
+                .split('')
+                .map((item) => item.charCodeAt(0));
+            const firstExpected = [
+                15, 216, 88, 212, 194, 59, 29, 40, 180, 63, 87, 57, 130, 116,
+                247, 175,
+            ];
+            expect(first).to.deep.equal(firstExpected);
+        });
     });
 
     describe('submission encryption', () => {

--- a/packages/enketo-express/test/client/encryptor.spec.js
+++ b/packages/enketo-express/test/client/encryptor.spec.js
@@ -242,5 +242,92 @@ describe('Encryptor', () => {
                 })
                 .catch(done);
         });
+
+        it('generates a correct submission manifest for a submission with non-ASCII characters', (done) => {
+            const record = {
+                xml: '<root>café résumé naïve</root>',
+                instanceId: '1a2b',
+            };
+
+            encryptor
+                .encryptRecord(form, record)
+                .then((encryptedRecord) => {
+                    const doc = new DOMParser().parseFromString(
+                        encryptedRecord.xml,
+                        'text/xml'
+                    );
+                    expect(doc.querySelectorAll('data').length).to.equal(1);
+                    expect(doc.querySelector('data').namespaceURI).to.equal(
+                        SUBMISSION_NS
+                    );
+                    expect(
+                        doc.querySelector('data').getAttribute('id')
+                    ).to.equal('abc');
+                    expect(
+                        doc.querySelector('data').getAttribute('version')
+                    ).to.equal('2');
+                    expect(
+                        doc.querySelector('data').getAttribute('encrypted')
+                    ).to.equal('yes');
+                    expect(
+                        doc.querySelectorAll('data > base64EncryptedKey').length
+                    ).to.equal(1);
+                    expect(
+                        doc.querySelector('data > base64EncryptedKey')
+                            .textContent
+                    ).to.match(/.+==$/);
+                    expect(
+                        doc.querySelector('data > base64EncryptedKey')
+                            .namespaceURI
+                    ).to.equal(SUBMISSION_NS);
+                    expect(doc.querySelectorAll('data > meta').length).to.equal(
+                        1
+                    );
+                    expect(
+                        doc.querySelector('data > meta').namespaceURI
+                    ).to.equal(XFORMS_NS);
+                    expect(
+                        doc.querySelectorAll('data > meta > instanceID').length
+                    ).to.equal(1);
+                    expect(
+                        doc.querySelector('data > meta > instanceID')
+                            .textContent
+                    ).to.equal('1a2b');
+                    expect(
+                        doc.querySelector('data > meta > instanceID')
+                            .namespaceURI
+                    ).to.equal(XFORMS_NS);
+                    expect(
+                        doc.querySelectorAll(
+                            'data > base64EncryptedElementSignature'
+                        ).length
+                    ).to.equal(1);
+                    expect(
+                        doc.querySelector(
+                            'data > base64EncryptedElementSignature'
+                        ).textContent
+                    ).to.match(/.+==$/);
+                    expect(
+                        doc.querySelector(
+                            'data > base64EncryptedElementSignature'
+                        ).namespaceURI
+                    ).to.equal(SUBMISSION_NS);
+                    expect(
+                        doc.querySelector('data > encryptedXmlFile').textContent
+                    ).to.equal('submission.xml.enc');
+                    expect(
+                        doc.querySelector('data >encryptedXmlFile').namespaceURI
+                    ).to.equal(SUBMISSION_NS);
+                    // only used by Enketo temporarily and then removed:
+                    expect(
+                        doc
+                            .querySelector('data >encryptedXmlFile')
+                            .getAttribute('type')
+                    ).to.equal('file');
+
+                    done();
+                })
+                .catch(done);
+        });
     });
 });


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
2. [ ] assign yourself
3. [x] fill in the template below and delete template comments
4. [ ] update all related docs (README, inline, etc.), if any
5. [x] review thyself: read the diff and repro the preview as written
6. [x] undraft PR & confirm that CI passes
7. [x] request reviewers & improve according to review
8. [ ] delete this section before merging


### 📣 Summary
UTF-8 encode submission XML before generating MD5 hash used in building  `base64EncryptedElementSignature`

### 📖 Description
UTF-8 encoding the submission XML will resolve signature verification failure for submissions that contain non-ASCII characters.


I have verified this PR works by manually testing (see CONTRIBUTING.md):

- [x] Online form submission
- [ ] Offline form submission
- [ ] Saving offline drafts
- [ ] Loading offline drafts
- [ ] Editing submissions
- [ ] Form preview
- [ ] None of the above
