### PR TITLE
fix(editSubmission): fix record repeat data on merge DEV-42

### DIFF
--- a/packages/enketo-core/src/js/form-model.js
+++ b/packages/enketo-core/src/js/form-model.js
@@ -405,7 +405,7 @@ FormModel.prototype.mergeXml = function (recordStr) {
      * when non existent, creates an empty node.
      * This fixes some situations where, when loading editing data,
      * repeat nodes aren't properly returned, crashing editing.
-     **/
+     */
 
     // Need to use the raw model without transformations
     const modelDoc = new DOMParser().parseFromString(

--- a/packages/enketo-core/src/js/form-model.js
+++ b/packages/enketo-core/src/js/form-model.js
@@ -389,6 +389,9 @@ FormModel.prototype.mergeXml = function (recordStr) {
         templateEls[i].remove();
     }
 
+    // Fix missing repeat nodes that may break editing
+    this.fixRecordRepeatData(record);
+
     /**
      * To comply with quirky behaviour of repeats in XForms, we manually create the correct number of repeat instances
      * before merging. This resolves these two issues:
@@ -1552,6 +1555,71 @@ FormModel.prototype.evaluate = function (
 
         return response;
     }
+};
+
+/**
+ * This function checks the existence of a template node and
+ * when non existent, creates an empty node.
+ * This fixes some situations where, when loading editing data,
+ * repeat nodes aren't properly returned, crashing editing.
+ *
+ * @param {XMLDocument} recordDoc
+ */
+FormModel.prototype.fixRecordRepeatData = function (recordDoc) {
+    // Need to use the raw model without transformations
+    const modelDoc = new DOMParser().parseFromString(
+        this.data.modelStr,
+        'text/xml'
+    );
+
+    const modelInstance = modelDoc.querySelector('model > instance');
+
+    // Check for a missing template node and if so
+    // creates an empty node. This fixes some situations
+    // in editing where accessing nodes data crashes editing
+    // (not the best practice to create a function inside of another
+    // function, but it's a recursive and very contextual function only
+    // used in this function)
+    const fixNode = (node, modelNode) => {
+        // get the model element for the current instance node
+        const modelEl = Array.from(modelNode.children).find(
+            (child) => child.nodeName === node.nodeName
+        );
+
+        // If no model element is found, there's nothing to check
+        if (!modelEl) return;
+
+        const isTemplate =
+            modelEl.hasAttribute('jr:template') ||
+            modelEl.hasAttribute('template');
+        Array.from(node.children).forEach((childNode) => {
+            fixNode(childNode, modelEl);
+        });
+
+        if (isTemplate) {
+            const templateChildren = Array.from(modelEl.children).filter(
+                (child) =>
+                    child.hasAttribute('jr:template') ||
+                    child.hasAttribute('template')
+            );
+            templateChildren.forEach((templateChild) => {
+                const templateName = templateChild.nodeName;
+                const existingInstances = Array.from(node.children).filter(
+                    (child) => child.nodeName === templateName
+                );
+                if (existingInstances.length === 0) {
+                    // No instances exist, create an empty one
+                    const newInstance = document.createElementNS(
+                        null,
+                        templateName
+                    );
+                    node.appendChild(newInstance);
+                }
+            });
+        }
+    };
+
+    fixNode(recordDoc.documentElement, modelInstance);
 };
 
 /**


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
2. [x] assign yourself
3. [x] fill in the template below and delete template comments
4. [x] update all related docs (README, inline, etc.), if any
5. [x] review thyself: read the diff and repro the preview as written
6. [x] undraft PR & confirm that CI passes
7. [x] request reviewers & improve according to review
8. [ ] delete this section before merging


### 📣 Summary
This PR fixes a bug where Enketo crashes when opening submissions for editing under certain conditions using repeats and data from repeating groups.


### 💭 Notes
To avoid the error a function was created to fix the existing data prior to loading it for editing.
The breaking situation involves the form trying to access non existent nodes duo to non filled data.
The created function adds an empty repeat node where needed to fix the issue.

I have verified this PR works by manually testing (see CONTRIBUTING.md):

- [x] Online form submission
- [x] Offline form submission
- [x] Saving offline drafts
- [x] Loading offline drafts
- [x] Editing submissions
- [x] Form preview
- [ ] None of the above


### 👀 Preview steps
1. ℹ️ have an account
2. Create a project with repeats. The 
situation is very specific, so there's this project ready for testing: [RFG_Simple.xlsx](https://github.com/user-attachments/files/21998269/RFG_Simple.xlsx)
3. Deploy the project
4. Fill the form in the following manner:
5. Add 3 names (eg.: Bob, Joe, Mila)
6. Add contact information only for the 1st and 3rd
7. Submit
8. Try to edit the submission
9. 🔴 [on main] Enketo should crash when trying to edit that submission
10. 🟢 [on PR] Editing should work properly
