### PR TITLE
fix(audioRecording): reset form only after dismissing the success modal DEV-977

### DIFF
--- a/packages/enketo-express/public/js/src/module/controller-webform.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform.js
@@ -447,8 +447,13 @@ function _submitRecord(survey) {
                 }, 1200);
             } else {
                 msg = msg.length > 0 ? msg : t('alert.submissionsuccess.msg');
-                gui.alert(msg, t('alert.submissionsuccess.heading'), level);
-                _resetForm(survey);
+                gui.alert(
+                    msg,
+                    t('alert.submissionsuccess.heading'),
+                    level
+                ).then(() => {
+                    _resetForm(survey);
+                });
             }
         })
         .catch((result) => {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
2. [x] assign yourself
3. [x] fill in the template below and delete template comments
4. [x] update all related docs (README, inline, etc.), if any
5. [x] review thyself: read the diff and repro the preview as written
6. [ ] undraft PR & confirm that CI passes
7. [ ] request reviewers & improve according to review
8. [ ] delete this section before merging


### 📣 Summary
Resetting a form with a background audio triggers a background audio disclaimer modal which was auto-dismissing the submission success modal when submitting an online form.
This PR implements a fix to wait for the dismissal of the success message to trigger the reset of the form.

I have verified this PR works by manually testing (see CONTRIBUTING.md):

- [x] Online form submission
- [x] Offline form submission
- [x] Saving offline drafts
- [x] Loading offline drafts
- [x] Editing submissions
- [x] Form preview
- [ ] None of the above


### 👀 Preview steps
1. ℹ️ have an account
1. ℹ️ have a project with background audio
1. ℹ️ deploy the form and open it for Online submission
3. Submit a form response
4. 🔴 [on main] The submit success message appears and is quickly be replaced by the background audio message
5. 🟢 [on PR] The submit success message appears and only when it's closed the background audio message will appear to wait for the next form filling
