### PR TITLE
feat(serverResponse): display server response on submission error DEV-993

### DIFF
--- a/packages/enketo-express/public/js/src/module/connection.js
+++ b/packages/enketo-express/public/js/src/module/connection.js
@@ -162,12 +162,11 @@ function _uploadBatch(recordBatch) {
                 failedFiles: recordBatch.failedFiles
                     ? recordBatch.failedFiles
                     : undefined,
-                response,
+                message: undefined,
             };
 
-            if (response.status === 400) {
-                // 400 is a generic error. Any message returned by the server is probably more useful.
-                // Other more specific statusCodes will get hardcoded and translated messages.
+            // Note: OpenRosa servers return 201 or 202 status codes upon successful submission.
+            if (response.status !== 201 && response.status !== 202) {
                 return response.text().then((text) => {
                     const xmlResponse = parser.parseFromString(
                         text,
@@ -179,13 +178,14 @@ function _uploadBatch(recordBatch) {
                         );
                         if (messageEl) {
                             result.message = messageEl.textContent;
+                        } else {
+                            result.message = text;
                         }
+                    } else {
+                        result.message = text;
                     }
                     throw result;
                 });
-            }
-            if (response.status !== 201 && response.status !== 202) {
-                throw result;
             } else {
                 return result;
             }

--- a/packages/enketo-express/public/js/src/module/connection.js
+++ b/packages/enketo-express/public/js/src/module/connection.js
@@ -186,9 +186,8 @@ function _uploadBatch(recordBatch) {
                     }
                     throw result;
                 });
-            } else {
-                return result;
             }
+            return result;
         })
         .catch((error) => {
             if (

--- a/packages/enketo-express/public/js/src/module/connection.js
+++ b/packages/enketo-express/public/js/src/module/connection.js
@@ -162,6 +162,7 @@ function _uploadBatch(recordBatch) {
                 failedFiles: recordBatch.failedFiles
                     ? recordBatch.failedFiles
                     : undefined,
+                response,
             };
 
             if (response.status === 400) {

--- a/packages/enketo-express/public/js/src/module/controller-webform.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform.js
@@ -456,7 +456,7 @@ function _submitRecord(survey) {
                 });
             }
         })
-        .catch(async (result) => {
+        .catch((result) => {
             let message;
             result = result || {};
             console.error('submission failed', result);
@@ -469,8 +469,7 @@ function _submitRecord(survey) {
                     },
                 });
             } else {
-                message =
-                    result.message || (await gui.getErrorResponseMsg(result));
+                message = gui.getErrorResponseMsg(result);
             }
             gui.alert(message, t('alert.submissionerror.heading'));
         });

--- a/packages/enketo-express/public/js/src/module/controller-webform.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform.js
@@ -456,7 +456,7 @@ function _submitRecord(survey) {
                 });
             }
         })
-        .catch((result) => {
+        .catch(async (result) => {
             let message;
             result = result || {};
             console.error('submission failed', result);
@@ -470,7 +470,7 @@ function _submitRecord(survey) {
                 });
             } else {
                 message =
-                    result.message || gui.getErrorResponseMsg(result.status);
+                    result.message || (await gui.getErrorResponseMsg(result));
             }
             gui.alert(message, t('alert.submissionerror.heading'));
         });

--- a/packages/enketo-express/public/js/src/module/gui.js
+++ b/packages/enketo-express/public/js/src/module/gui.js
@@ -607,8 +607,9 @@ updateStatus = {
     },
 };
 
-async function getErrorResponseMsg(result) {
-    let { status: statusCode, response } = result;
+function getErrorResponseMsg(result) {
+    // message is parsed from the server response in connection.js
+    let { status: statusCode, message } = result;
     let msg;
     const supportEmailObj = {
         supportEmail: settings.supportEmail,
@@ -619,7 +620,6 @@ async function getErrorResponseMsg(result) {
         0: t('submission.http0'),
         200: `${t('submission.http2xx')}<br/>${contactSupport}`,
         '2xx': `${t('submission.http2xx')}<br/>${contactSupport}`,
-        400: `${t('submission.http400')}<br/>${contactAdmin}`,
         401: t('submission.http401'),
         403: `${t('submission.http403')}<br/>${contactAdmin}`,
         404: t('submission.http404'),
@@ -638,9 +638,8 @@ async function getErrorResponseMsg(result) {
     if (statusMap[statusCode]) {
         msg = `${statusMap[statusCode]} (${statusCode})`;
     } else if (statusMap[statusCode.replace(statusCode.substring(1), 'xx')]) {
-        const parsedMessage = await parseMessageFromResponse(response);
-        if (parsedMessage) {
-            msg = `${parsedMessage} (${statusCode})`;
+        if (message) {
+            msg = `${message} (${statusCode})`;
         } else {
             msg = `${
                 statusMap[statusCode.replace(statusCode.substring(1), 'xx')]
@@ -651,25 +650,6 @@ async function getErrorResponseMsg(result) {
     }
 
     return msg;
-}
-
-async function parseMessageFromResponse(response) {
-    const text = await response.text();
-    const xml = new DOMParser().parseFromString(text, 'text/xml');
-
-    if (xml.querySelector('parseerror')) {
-        // response is not a valid XML
-        return null;
-    }
-
-    const messageEl = xml.querySelector('OpenRosaResponse > message');
-
-    if (!messageEl) {
-        // response does not contain the expected structure
-        return null;
-    }
-
-    return messageEl.textContent;
 }
 
 $(document).ready(() => {

--- a/packages/enketo-express/public/js/src/module/records-queue.js
+++ b/packages/enketo-express/public/js/src/module/records-queue.js
@@ -324,7 +324,7 @@ const uploadQueue = async (
             }
 
             // if any non HTTP error occurs, output the error.message
-            errorMsg = error.message || gui.getErrorResponseMsg(error.status);
+            errorMsg = error.message || (await gui.getErrorResponseMsg(error));
             uploadProgress.update(record.instanceId, 'error', errorMsg);
         }
     }

--- a/packages/enketo-express/public/js/src/module/records-queue.js
+++ b/packages/enketo-express/public/js/src/module/records-queue.js
@@ -317,14 +317,14 @@ const uploadQueue = async (
 
             await store.record.remove(record.instanceId);
             await store.property.addSubmittedInstanceId(record);
-        } catch (error) {
+        } catch (result) {
             // catch 401 responses (1 of them)
-            if (error.status === 401) {
-                authError = error;
+            if (result.status === 401) {
+                authError = result;
             }
 
             // if any non HTTP error occurs, output the error.message
-            errorMsg = error.message || (await gui.getErrorResponseMsg(error));
+            errorMsg = gui.getErrorResponseMsg(result);
             uploadProgress.update(record.instanceId, 'error', errorMsg);
         }
     }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
2. [x] assign yourself
3. [x] fill in the template below and delete template comments
4. [x] update all related docs (README, inline, etc.), if any
5. [x] review thyself: read the diff and repro the preview as written
6. [x] undraft PR & confirm that CI passes
7. [x] request reviewers & improve according to review
8. [ ] delete this section before merging


### 📣 Summary
This PR parses and displays the server response message when available on a submission fail.


### 📖 Description
- For now, only unhandled status codes will be checked. e.g: 402.
- If the server response is an `OpenRosaResponse` and a `message` tag is present for unhandled status codes, the message returned from the server will be displayed.
- No translation is applied to the message at this moment

I have verified this PR works by manually testing (see CONTRIBUTING.md):

- [x] Online form submission
- [x] Offline form submission
- [x] Saving offline drafts
- [x] Loading offline drafts
- [x] Editing submissions
- [x] Form preview
- [ ] None of the above


### 👀 Preview steps
Template:
1. ℹ️ have an account and a project
2. ℹ️ make the account over usage limit for either submission or storage
3. Try to post a submission
4. 🔴 [on main] The displayed error is a generic "Unknown server error"
5. 🟢 [on PR] The displayed error reflects the message in the server response
