### PR TITLE
fix(modalMessage): fix __icon__ replacement in submission queued DEV-979

### DIFF
--- a/packages/enketo-express/public/js/src/module/records-queue.js
+++ b/packages/enketo-express/public/js/src/module/records-queue.js
@@ -247,7 +247,10 @@ const uploadQueue = async (
 
         if (isUserTriggered) {
             gui.alert(
-                `${t('record-list.msg2')}`,
+                t('record-list.msg2', {
+                    icon: `<span class="icon icon-pencil"> </span>`,
+                    interpolation: { escapeValue: false },
+                }),
                 t('alert.recordsavesuccess.finalmsg'),
                 'info',
                 10
@@ -353,7 +356,10 @@ const uploadQueue = async (
 
         if (isUserTriggered) {
             gui.alert(
-                `${t('record-list.msg2')}`,
+                t('record-list.msg2', {
+                    icon: `<span class="icon icon-pencil"> </span>`,
+                    interpolation: { escapeValue: false },
+                }),
                 t('alert.recordsavesuccess.finalmsg'),
                 'info',
                 10

--- a/packages/enketo-express/test/client/records-queue.spec.js
+++ b/packages/enketo-express/test/client/records-queue.spec.js
@@ -336,7 +336,10 @@ describe('Records queue', () => {
             const result = await records.uploadQueue({ isUserTriggered: true });
 
             expect(guiAlertStub).to.have.been.calledWith(
-                `${t('record-list.msg2')}`,
+                t('record-list.msg2', {
+                    icon: `<span class="icon icon-pencil"> </span>`,
+                    interpolation: { escapeValue: false },
+                }),
                 t('alert.recordsavesuccess.finalmsg'),
                 'info',
                 10


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
2. [ ] assign yourself
3. [ ] fill in the template below and delete template comments
4. [ ] update all related docs (README, inline, etc.), if any
5. [ ] review thyself: read the diff and repro the preview as written
6. [ ] undraft PR & confirm that CI passes
7. [ ] request reviewers & improve according to review
8. [ ] delete this section before merging


### 📣 Summary
This PR fixes the replacement of the `__icon__` for the modal messages when submission is queued.
The same message and replacement icon is already present in the side panel.

I have verified this PR works by manually testing (see CONTRIBUTING.md):

- [x] Online form submission
- [x] Offline form submission
- [x] Saving offline drafts
- [x] Loading offline drafts
- [x] Editing submissions
- [x] Form preview
- [ ] None of the above


### 👀 Preview steps
Template:
1. ℹ️ open a form for online/offline submissions
2. Make the network offline (can be simulated)
3. Post the submission
4. 🔴 [on main] The message displays the `__icon__` text
5. 🟢 [on PR] The `__icon__` is replaced by a pencil icon
