### PR TITLE
feat(widgetValidation): implement custom widget validation DEV-1036

### DIFF
--- a/packages/enketo-core/src/js/input.js
+++ b/packages/enketo-core/src/js/input.js
@@ -197,6 +197,13 @@ export default {
     },
     /**
      * @param {Element} control - form control HTML element
+     * @return {string|null} the error message from the element's dataset or null if none exists
+     */
+    getErrorMessage(control) {
+        return control.dataset.errorMessage || null;
+    },
+    /**
+     * @param {Element} control - form control HTML element
      * @return {string} element value
      */
     getVal(control) {

--- a/packages/enketo-core/src/js/widget.js
+++ b/packages/enketo-core/src/js/widget.js
@@ -214,7 +214,10 @@ class Widget {
      *
      * @return void
      */
-    validate() {}
+    validate() {
+        // Return is needed for linting purposes only
+        return undefined;
+    }
 
     /**
      * Sets a custom validation error message on the widget's element.

--- a/packages/enketo-core/src/js/widget.js
+++ b/packages/enketo-core/src/js/widget.js
@@ -214,9 +214,7 @@ class Widget {
      *
      * @return void
      */
-    validate() {
-        return;
-    }
+    validate() {}
 
     /**
      * Sets a custom validation error message on the widget's element.

--- a/packages/enketo-core/src/js/widget.js
+++ b/packages/enketo-core/src/js/widget.js
@@ -206,6 +206,38 @@ class Widget {
     }
 
     /**
+     * Gives the widget a chance to apply a custom validation before submitting the form.
+     * This is useful for widgets that need to block the submission based on some custom logic
+     * (e.g., if a recording is still in progress, if an image is still loading...)
+     *
+     * Widgets should use `setValidationError(message)` to set a custom validation error message
+     *
+     * @return void
+     */
+    validate() {
+        return;
+    }
+
+    /**
+     * Sets a custom validation error message on the widget's element.
+     * If a message is provided, it sets the 'data-error-message' attribute on the element.
+     * If no message is provided, it clears any existing error message.
+     *
+     * @param {string} message - The custom validation error message to set. If null, clears the error message.
+     */
+    setValidationError(message) {
+        if (!this.question) return;
+        const errorMsgEl = this.question.querySelector('.custom-error-msg');
+        if (message) {
+            this.element.dataset.errorMessage = message;
+            errorMsgEl.innerText = message;
+        } else {
+            delete this.element.dataset.errorMessage;
+            errorMsgEl.innerText = '';
+        }
+    }
+
+    /**
      * Returns its own name.
      *
      * @static

--- a/packages/enketo-core/src/js/widgets-controller.js
+++ b/packages/enketo-core/src/js/widgets-controller.js
@@ -175,7 +175,8 @@ async function beforeSubmit() {
     for (const Widget of widgets) {
         const elements = _getElements(formElement, Widget.selector);
         for (const element of elements) {
-            widgetInstances.push(data.get(element, Widget.name));
+            const widgetInstance = data.get(element, Widget.name);
+            if (widgetInstance) widgetInstances.push(widgetInstance);
         }
     }
 
@@ -183,6 +184,23 @@ async function beforeSubmit() {
     return Promise.all(
         widgetInstances.map((widgetInstance) => widgetInstance.beforeSubmit())
     );
+}
+
+/**
+ * Gives the widgets the chance to apply a custom validation before submitting the form.
+ *
+ * @return {Promise<void>} A promise that resolves when all widgets have prepared their data.
+ */
+function validate() {
+    // Grab all the widget instances from the form elements
+    for (const Widget of widgets) {
+        const elements = _getElements(formElement, Widget.selector);
+        for (const element of elements) {
+            const widgetInstance = data.get(element, Widget.name);
+            widgetInstance?.setValidationError(null); // resets any previous error
+            widgetInstance?.validate(); // run custom validation if existing
+        }
+    }
 }
 
 /**
@@ -364,4 +382,5 @@ export default {
     disable,
     reset,
     beforeSubmit,
+    validate,
 };

--- a/packages/enketo-core/src/sass/core/_main.scss
+++ b/packages/enketo-core/src/sass/core/_main.scss
@@ -7,6 +7,7 @@ $media-margin: 10px;
 .or-appearance-page-break,
 .or-constraint-msg,
 .or-required-msg,
+.custom-error-msg,
 .or-relevant-msg,
 .invalid-value-msg,
 .option-wrapper .itemset-template,
@@ -588,6 +589,7 @@ legend .required {
 .invalid-constraint,
 .invalid-value,
 .invalid-required,
+.invalid-custom,
 .invalid-relevant {
     @include question-invalid;
 }
@@ -595,10 +597,12 @@ legend .required {
 .invalid-value .invalid-value-msg.active,
 .invalid-constraint .or-constraint-msg.active,
 .invalid-required .or-required-msg.active,
+.invalid-custom .custom-error-msg.active,
 .question.invalid-relevant .or-relevant-msg.active {
     display: block;
 }
 
+.custom-error-msg.active,
 .or-required-msg.active,
 .or-constraint-msg.active,
 .or-relevant-msg.active,

--- a/packages/enketo-core/src/sass/core/_print.scss
+++ b/packages/enketo-core/src/sass/core/_print.scss
@@ -62,6 +62,7 @@ h4::before {
     button,
     .invalid-required .or-required-msg.active,
     .invalid-constraint .or-constraint-msg.active,
+    .invalid-custom .custom-error-msg.active,
     .invalid-value .invalid-value-msg.active {
         display: none;
     }
@@ -219,7 +220,8 @@ input[type='checkbox'] {
 }
 
 .invalid-constraint,
-.invalid-required {
+.invalid-required,
+.invalid-custom {
     background: none;
     border: 1px solid red;
 }

--- a/packages/enketo-core/src/sass/grid/_main.scss
+++ b/packages/enketo-core/src/sass/grid/_main.scss
@@ -172,7 +172,8 @@ h4 + .or-repeat {
     }
 
     &.invalid-constraint,
-    &.invalid-required {
+    &.invalid-required,
+    &.invalid-custom {
         border-radius: 0;
         margin: $question-margin;
         padding: $question-padding;
@@ -232,6 +233,7 @@ h4 + .or-repeat {
     .or-constraint-msg,
     .or-required-msg,
     .or-relevant-msg,
+    .custom-error-msg,
     .invalid-value-msg {
         order: 5;
     }

--- a/packages/enketo-core/src/sass/grid/_print.scss
+++ b/packages/enketo-core/src/sass/grid/_print.scss
@@ -86,7 +86,9 @@ $printBaseFontSize: 10px;
     background: #ffffff;
 }
 
-.question:not(.or-appearance-label):not(.or-appearance-compact):not(.or-appearance-quickcompact) {
+.question:not(.or-appearance-label):not(.or-appearance-compact):not(
+        .or-appearance-quickcompact
+    ) {
     label {
         $line-h: 15px;
 
@@ -170,7 +172,7 @@ $printBaseFontSize: 10px;
     vertical-align: top; //padding: 5px 5px 12px 5px;
 
     // unfortunately we cannot target actual page-breaks to provide a top-border
-    &:not(.invalid-required):not(.invalid-constraint) {
+    &:not(.invalid-required):not(.invalid-constraint):not(.invalid-custom) {
         border-top: $grid-border;
     }
 }

--- a/packages/enketo-core/src/widget/audio/audio.js
+++ b/packages/enketo-core/src/widget/audio/audio.js
@@ -13,9 +13,13 @@ import fileManager from 'enketo/file-manager';
  * @augments Widget
  */
 
+const elementsToBeDisabled = [
+    '.widget.audio-widget .step-action-select .btn-record',
+];
+
 class AudioWidget extends Widget {
     static get selector() {
-        return '.question:not(.or-appearance-draw):not(.or-appearance-signature):not(.or-appearance-annotate) input[type="file"][accept="audio/*"]';
+        return '.question:not(.or-appearance-draw):not(.or-appearance-signature):not(.or-appearance-annotate) input[accept="audio/*"]';
     }
 
     _init() {
@@ -26,8 +30,6 @@ class AudioWidget extends Widget {
         this.audioQuality = this.element.dataset.quality || 'normal'; // Get audio quality from data attribute
         this.fileName = existingFilename || ''; // A filename to be used for data validation purposes
         this.audioBlob = null; // To store the recorded audio blob
-
-        this.overlay = null;
 
         this.element.classList.add('hidden');
         this.element.dataset.audio = 'true'; // Indicate that this is an audio recording widget
@@ -42,7 +44,7 @@ class AudioWidget extends Widget {
                 `<div class="widget audio-widget"></div>`
             );
 
-        this.question.appendChild(fragment); // Append the new widget structure
+        this.element.after(fragment); // Append the new widget structure
 
         this.element.addEventListener('change', async (event) => {
             // If the input type is not 'file', do nothing
@@ -123,54 +125,6 @@ class AudioWidget extends Widget {
         if (fragment) widget.appendChild(fragment);
     }
 
-    /*
-     * This method shows an overlay on top of the question element
-     * to prevent user interaction while recording audio.
-     */
-    showOverlay() {
-        if (this.overlay) {
-            this.overlay.remove(); // Remove existing overlay if it exists
-        }
-        // Create a new overlay element and insert it at the beginning of the question
-        // This is used to prevent user interaction while recording audio
-        const fragment = document
-            .createRange()
-            .createContextualFragment(
-                `<div class="audio-widget-overlay fade-in"> </div>`
-            );
-        this.overlay = fragment.firstChild;
-        this.overlay.style.zIndex = 1000; // Ensure the overlay is on top
-        this.question.style.zIndex = 1010; // Set the question's z-index to be above the overlay
-        this.question.before(fragment);
-    }
-
-    /*
-     * This method hides the overlay that was shown during audio recording.
-     * It removes the overlay element after a fade-out animation.
-     */
-    hideOverlay() {
-        if (this.overlay) {
-            this.overlay.classList.remove('fade-in');
-
-            requestAnimationFrame(() => {
-                // Needed to ensure the fade-out animation is applied
-                this.overlay.classList.add('fade-out'); // Add fade-out class for animation
-
-                setTimeout(() => {
-                    this.overlay.remove(); // Remove the overlay element
-                    this.overlay = null;
-                    this.question.style.removeProperty('z-index'); // Reset the z-index of the question
-                }, 300); // Delay to allow any animations to complete
-            });
-        }
-    }
-
-    /**
-     * This method shows the action select step where the user can
-     * choose to start recording audio or upload an existing audio file.
-     * It creates the necessary UI elements and event listeners
-     * for both actions.
-     */
     showActionSelectStep() {
         this.updateValue(null);
         this.element.type = 'text'; // Will consider the input as a text for validation purposes
@@ -218,6 +172,19 @@ class AudioWidget extends Widget {
         });
 
         this.setWidgetContent(stepFragment);
+    }
+
+    /**
+     * Before submitting the form, this method is called to check if an audio recording is in progress.
+     * If a recording is in progress, it throws an error.
+     * @returns {Promise<void>}
+     */
+    async validate() {
+        if (this.audioRecorder.isRecording() || this.audioRecorder.isPaused()) {
+            this.setValidationError(
+                t('audioRecording.error.recordingInProgress')
+            );
+        }
     }
 
     /**
@@ -271,6 +238,8 @@ class AudioWidget extends Widget {
         buttonStop.addEventListener('click', async () => {
             await this.audioRecorder.stopRecording();
 
+            this.setValidationError(null); // Clear previous validation error
+
             const blob = await this.audioRecorder.getRecordedFile(); // Store the recorded audio file
 
             this.fileName = this.getFileName(); // Get the filename for the recording
@@ -283,7 +252,7 @@ class AudioWidget extends Widget {
             // When value is set, it will trigger the playback step
             this.showPlaybackStep();
 
-            this.hideOverlay();
+            this.restoreElements();
         });
 
         this.setWidgetContent(stepFragment);
@@ -292,7 +261,25 @@ class AudioWidget extends Widget {
 
         this.watchAudioRecording(timeDisplay); // Start watching the audio recording
 
-        this.showOverlay(); // Show the overlay to prevent interaction to other elements during recording
+        this.disableElements();
+    }
+
+    disableElements() {
+        elementsToBeDisabled.forEach((selector) => {
+            document.querySelectorAll(selector).forEach((el) => {
+                el.dataset.previousDisabledState = el.disabled;
+                el.disabled = true;
+            });
+        });
+    }
+
+    restoreElements() {
+        elementsToBeDisabled.forEach((selector) => {
+            document.querySelectorAll(selector).forEach((el) => {
+                el.disabled = el.dataset.previousDisabledState === 'true';
+                el.removeAttribute('data-previous-disabled-state');
+            });
+        });
     }
 
     /**

--- a/packages/enketo-core/src/widget/audio/audio.js
+++ b/packages/enketo-core/src/widget/audio/audio.js
@@ -179,12 +179,28 @@ class AudioWidget extends Widget {
      * If a recording is in progress, it throws an error.
      * @returns {Promise<void>}
      */
-    async validate() {
+    validate() {
         if (this.audioRecorder.isRecording() || this.audioRecorder.isPaused()) {
             this.setValidationError(
                 t('audioRecording.error.recordingInProgress')
             );
         }
+    }
+
+    /**
+     * Before submitting the form, this method is called to check if an audio recording is in progress.
+     * If a recording is in progress, it throws an error.
+     * @param {*} isSavingDraft
+     * @returns
+     */
+    beforeSubmit() {
+        // This will only be called when saving drafts, since the validate() method
+        // will block submissions and page navigation when a recording is in progress.
+        if (this.audioRecorder.isRecording() || this.audioRecorder.isPaused()) {
+            // Throw an error if a recording is in progress
+            throw new Error(t('audioRecording.error.recordingInProgress'));
+        }
+        return Promise.resolve();
     }
 
     /**

--- a/packages/enketo-core/src/widget/audio/audio.js
+++ b/packages/enketo-core/src/widget/audio/audio.js
@@ -15,7 +15,7 @@ import fileManager from 'enketo/file-manager';
 
 class AudioWidget extends Widget {
     static get selector() {
-        return '.question:not(.or-appearance-draw):not(.or-appearance-signature):not(.or-appearance-annotate) input[type="file"][accept="audio/*"]';
+        return '.question:not(.or-appearance-draw):not(.or-appearance-signature):not(.or-appearance-annotate) input[accept="audio/*"]';
     }
 
     _init() {

--- a/packages/enketo-core/src/widget/audio/audio.scss
+++ b/packages/enketo-core/src/widget/audio/audio.scss
@@ -1,32 +1,3 @@
-@keyframes audio-widget-overlay-fade-in {
-    0% {
-        opacity: 0; /* Start fully transparent */
-    }
-    100% {
-        opacity: 0.5; /* End fully opaque */
-    }
-}
-
-.audio-widget-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: $body-bg;
-    opacity: 0;
-    cursor: not-allowed;
-    z-index: 1000;
-}
-
-.audio-widget-overlay.fade-in {
-    animation: audio-widget-overlay-fade-in 1s forwards; /* Fade-in effect */
-}
-
-.audio-widget-overlay.fade-out {
-    animation: audio-widget-overlay-fade-in 0.3s reverse forwards; /* Fade-out effect */
-}
-
 .audio-widget {
     width: 100%;
 

--- a/packages/enketo-core/src/widget/audio/audio.scss
+++ b/packages/enketo-core/src/widget/audio/audio.scss
@@ -1,3 +1,32 @@
+@keyframes audio-widget-overlay-fade-in {
+    0% {
+        opacity: 0; /* Start fully transparent */
+    }
+    100% {
+        opacity: 0.5; /* End fully opaque */
+    }
+}
+
+.audio-widget-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: $body-bg;
+    opacity: 0;
+    cursor: not-allowed;
+    z-index: 1000;
+}
+
+.audio-widget-overlay.fade-in {
+    animation: audio-widget-overlay-fade-in 1s forwards; /* Fade-in effect */
+}
+
+.audio-widget-overlay.fade-out {
+    animation: audio-widget-overlay-fade-in 0.3s reverse forwards; /* Fade-out effect */
+}
+
 .audio-widget {
     width: 100%;
 

--- a/packages/enketo-core/src/widget/comment/commentwidget.js
+++ b/packages/enketo-core/src/widget/comment/commentwidget.js
@@ -81,7 +81,8 @@ class Comment extends Widget {
     _commentHasError() {
         return (
             this.commentQuestion.classList.contains('invalid-required') ||
-            this.commentQuestion.classList.contains('invalid-constraint')
+            this.commentQuestion.classList.contains('invalid-constraint') ||
+            this.commentQuestion.classList.contains('invalid-custom')
         );
     }
 

--- a/packages/enketo-core/src/widget/comment/commentwidget.scss
+++ b/packages/enketo-core/src/widget/comment/commentwidget.scss
@@ -63,11 +63,13 @@ $padding: 30px;
     // should stay hidden.
     .or-required-msg.active,
     .or-constraint-msg.active,
+    .custom-error-msg.active,
     .invalid-value-msg.active {
         display: none;
     }
     .invalid-required > .or-required-msg,
     .invalid-constraint > .or-constraint-msg,
+    .invalid-custom > .custom-error-msg,
     .invalid-value > .invalid-value-msg {
         display: block;
     }

--- a/packages/enketo-express/locales/src/en/translation.json
+++ b/packages/enketo-express/locales/src/en/translation.json
@@ -138,8 +138,7 @@
             "noMicrophone": "No microphone found on this device.",
             "notSupported": "Audio recording is not supported in this browser.",
             "unknownError": "Failed to access microphone. Check your browser settings and permissions.",
-            "recordingError": "An error occurred while trying to record audio.",
-            "recordingInProgress": "The current audio recording needs to be stopped before continuing."
+            "recordingError": "An error occurred while trying to record audio."
         },
         "startRecording": "Start Recording",
         "uploadAudioFile": "Upload audio File",

--- a/packages/enketo-express/locales/src/en/translation.json
+++ b/packages/enketo-express/locales/src/en/translation.json
@@ -138,7 +138,8 @@
             "noMicrophone": "No microphone found on this device.",
             "notSupported": "Audio recording is not supported in this browser.",
             "unknownError": "Failed to access microphone. Check your browser settings and permissions.",
-            "recordingError": "An error occurred while trying to record audio."
+            "recordingError": "An error occurred while trying to record audio.",
+            "recordingInProgress": "The current audio recording needs to be stopped before continuing."
         },
         "startRecording": "Start Recording",
         "uploadAudioFile": "Upload audio File",

--- a/packages/enketo-express/public/js/src/module/gui.js
+++ b/packages/enketo-express/public/js/src/module/gui.js
@@ -653,6 +653,8 @@ function getErrorResponseMsg(result) {
                 statusMap[statusCode.replace(statusCode.substring(1), 'xx')]
             } (${statusCode})`;
         }
+    } else if (message) {
+        msg = `${message}`;
     } else {
         msg = `${t('error.unknown')} (${statusCode})`;
     }

--- a/packages/enketo-transformer/src/xsl/openrosa2html5form.xsl
+++ b/packages/enketo-transformer/src/xsl/openrosa2html5form.xsl
@@ -332,7 +332,7 @@ XSLT Stylesheet that transforms OpenRosa style (X)Forms into valid HTMl5 forms
                 </h4>
             </xsl:if>
             <xsl:apply-templates select="*[not(self::xf:label or self::xf:hint)]"/>
-            <xsl:call-template name="constraint-and-required-msg" >
+            <xsl:call-template name="error-messages" >
                 <xsl:with-param name="binding" select="$binding"/>
             </xsl:call-template>
             <xsl:text>
@@ -559,7 +559,7 @@ XSLT Stylesheet that transforms OpenRosa style (X)Forms into valid HTMl5 forms
                             <xsl:if test="./xf:setvalue[@event] or ./odk:setgeopoint[@event]">
                                 <xsl:apply-templates select="./xf:setvalue[@event] | ./odk:setgeopoint[@event]" />
                             </xsl:if>
-                            <xsl:call-template name="constraint-and-required-msg" >
+                            <xsl:call-template name="error-messages" >
                                  <xsl:with-param name="binding" select="$binding"/>
                             </xsl:call-template>
                         </xsl:if>
@@ -886,7 +886,7 @@ XSLT Stylesheet that transforms OpenRosa style (X)Forms into valid HTMl5 forms
             <xsl:if test="./xf:setvalue[@event] or ./odk:setgeopoint[@event]">
                 <xsl:apply-templates select="./xf:setvalue[@event] | ./odk:setgeopoint[@event]" />
             </xsl:if>
-            <xsl:call-template name="constraint-and-required-msg" >
+            <xsl:call-template name="error-messages" >
                 <xsl:with-param name="binding" select="$binding"/>
             </xsl:call-template>
         </label>
@@ -973,7 +973,7 @@ XSLT Stylesheet that transforms OpenRosa style (X)Forms into valid HTMl5 forms
             <xsl:if test="./xf:setvalue[@event] or ./odk:setgeopoint[@event]">
                 <xsl:apply-templates select="./xf:setvalue[@event] | ./odk:setgeopoint[@event]" />
             </xsl:if>
-            <xsl:call-template name="constraint-and-required-msg" >
+            <xsl:call-template name="error-messages" >
                 <xsl:with-param name="binding" select="$binding"/>
             </xsl:call-template>
         </fieldset>
@@ -1285,8 +1285,9 @@ XSLT Stylesheet that transforms OpenRosa style (X)Forms into valid HTMl5 forms
         </xsl:choose>
     </xsl:template>
 
-    <xsl:template name="constraint-and-required-msg">
+    <xsl:template name="error-messages">
         <xsl:param name="binding"/>
+        <span class="custom-error-msg active"></span>
         <xsl:if test="string-length($binding/@constraint) &gt; 0">
             <xsl:choose>
                 <xsl:when test="$binding/@jr:constraintMsg">


### PR DESCRIPTION
### 📣 Summary
This PR implements a new custom widget validation, called right before submitting the form and taking precedence over `required` and `constraints`. It is available for widgets through the overwriting of the `validate` function.

### 💭 Notes
This PR only adds the validation functionality, but does not apply the validation in any widget.

### 👀 Preview steps

There's no user-facing changes. If needed, this can be tested in code in the following way:

- Pull the PR
- Pick a widget (e.g.: audio.js)
- Add the `validate` function
- Add any logic and use `setValidationError(error message)` to set the error in the widget: e.g.:
   ```javascript
   class AudioWidget extends Widget {
    ...
    validate() {
        if (!this.tries || this.tries < 3) {
            this.tries = this.tries ? this.tries + 1 : 1;
            this.setValidationError(
                `Not enough tries. Only ${this.tries} tries. Try again.`
            );
            return;
        }
        this.setValidationError(null);
    }
    ...
   }
   ```
- Call `setValidationError(null)` to clear the error
- Load a form containing the widget (e.g: [multipageAudio.xlsx](https://github.com/user-attachments/files/22660413/multipageAudio.xlsx))

- Try to submit the form and it should be blocked by the added logic if an error was set