### PR TITLE
test(transformer): ensure snapshots are consistent with testing results  DEV-1100

### DIFF
--- a/packages/enketo-transformer/test/snapshot.spec.ts
+++ b/packages/enketo-transformer/test/snapshot.spec.ts
@@ -132,7 +132,7 @@ describe('Snapshots', () => {
                     parser: 'xml',
                     plugins: ['@prettier/plugin-xml'],
                     xmlSelfClosingSpace: true,
-                    xmlWhitespaceSensitivity: 'ignore',
+                    xmlWhitespaceSensitivity: 'preserve',
                 })
                 // Reverses a change released in `@prettier/plugin-xml` 3.0.0. In prior
                 // versions, self-closing tags spanning multiple lines would place their


### PR DESCRIPTION
### 🗒️ Checklist

- [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
- [x] assign yourself
- [x] fill in the template below and delete template comments
- [x] update all related docs (README, inline, etc.), if any
- [x] I have verified this PR works by manually testing (see CONTRIBUTING.md):
    - [x] Online form submission
    - [x] Offline form submission
    - [x] Saving offline drafts
    - [x] Loading offline drafts
    - [x] Editing submissions
    - [x] Form preview
    - [ ] None of the above
- [x] review thyself: read the diff and repro the preview as written
- [x] undraft PR & confirm that CI passes
- [x] request reviewers & improve according to review
- [ ] delete this section before merging


### 💭 Notes

- Context: This issue was first seen in https://github.com/enketo/enketo/pull/1443, where CI tests failed in the commit https://github.com/enketo/enketo/pull/1443/commits/01eab49f5f555990d95282eb95f5eafd17cf8336 due to a difference in the snapshot - generated locally - and the test result that is compared to it.
- Failed CI can be seen [here](https://github.com/enketo/enketo/actions/runs/17999950535/job/51206813715) - sample change can be seen [here](https://github.com/enketo/enketo/actions/runs/17999950535/job/51206813715#step:7:21422)
- After further investigation we noticed that the difference was due to line breaks and white spaces.
- Snapshots are formatted using Prettier after it's generation, so from the tests, the difference seems to be due to some environment difference detected by Prettier, causing it to generate different results.
- By enforcing the preservation of white spaces we were able to get consistent results, causing the CI test to pass.
- This PR applies the fix tested in #1443 (described above)

### 👀 Preview steps
A [temporary PR](https://github.com/enketo/enketo/pull/1448) was created to illustrate the issue using main as a base. 
**Here's the test on that PR and also reference for the steps taken:**

#### First commit (https://github.com/enketo/enketo/pull/1448/commits/e2dd226e062e072df5cc27da8bb9802e4d4e3862):
- `yarn workspace enketo-transformer test:update-snapshots` was used to update snapshots without any modification.
- the generated snapshots failed the tests having differences like:
<img width="822" height="125" alt="image" src="https://github.com/user-attachments/assets/63be9596-f810-446d-a115-be21370168c4" />
- (this snapshot update was tested locally in 2 different computers with the same result)

#### Second commit (https://github.com/enketo/enketo/pull/1448/commits/67d50a92623fdedff933114653ddb00a503fbb72):
- Snapshots were updated after modifying the whitespace sensitivity parameter to  `preserve` at https://github.com/enketo/enketo/blob/67d50a92623fdedff933114653ddb00a503fbb72/packages/enketo-transformer/test/snapshot.spec.ts#L135
- ✅ tests passed

Steps:
- Pull main
- update snapshots locally with `yarn workspace enketo-transformer test:update-snapshots`
- run tests locally with `yarn test` or specific to transformer with ``yarn workspace enketo-transformer test`
- local tests should pass
- push changes to a branch to check CI tests
- CI tests for enketo-transformer will fail
- change prettier's whitespace sensitivity to `preserve`
- update snapshots again
- push changes again to check CI
- CI tests should pass now
