### PR TITLE
feat(audioRecording): change background audio modal button text DEV-1089

### DIFF
--- a/packages/enketo-core/src/widget/background-audio/background-audio.js
+++ b/packages/enketo-core/src/widget/background-audio/background-audio.js
@@ -202,7 +202,9 @@ class BackgroundAudioWidget extends Widget {
             .alert(
                 t('audioRecording.backgroundDisclaimer.msg'),
                 t('audioRecording.backgroundDisclaimer.heading'),
-                'normal'
+                'normal',
+                null,
+                t('audioRecording.backgroundDisclaimer.buttonText')
             )
             .then(() =>
                 this.audioRecorder.requestPermissions(this.audioQuality)

--- a/packages/enketo-express/locales/src/en/translation.json
+++ b/packages/enketo-express/locales/src/en/translation.json
@@ -150,7 +150,8 @@
                 "You can use the volume indicator to make sure the microphone is close enough to the sound you need to record.",
                 "To stop the recording please exit this form.",
                 "For more information please contact the person who asked you to collect data."
-            ]
+            ],
+            "buttonText": "Ok, start Recording"
         },
         "hasRecordedAudio": "This submission has a background audio recording."
     },

--- a/packages/enketo-express/public/js/src/module/gui.js
+++ b/packages/enketo-express/public/js/src/module/gui.js
@@ -206,10 +206,16 @@ function feedback(message, duration, heading = t('feedback.header')) {
  * @param {string=} heading - heading to show
  * @param {string=} level - css class or normal (no styling) ('alert', 'info', 'warning', 'error', 'success')
  * @param {number=} duration - duration in secondsafter which dialog should self-destruct
- * @param {string=} buttonText - text for the button (default: OK)
+ * @param {string=} buttonText - text for the button
  * @returns {Promise} resolves when the alert is closed
  */
-function alert(message, heading, level, duration, buttonText) {
+function alert(
+    message,
+    heading,
+    level,
+    duration,
+    buttonText = t('alert.validationsuccess.heading')
+) {
     return new Promise((resolve) => {
         level = level || 'error';
         vex.closeAll();
@@ -219,7 +225,7 @@ function alert(message, heading, level, duration, buttonText) {
             messageClassName: level === 'normal' ? '' : `alert-box ${level}`,
             buttons: [
                 {
-                    text: buttonText || t('alert.validationsuccess.heading'),
+                    text: buttonText,
                     type: 'submit',
                     className: 'btn btn-primary small',
                 },

--- a/packages/enketo-express/public/js/src/module/gui.js
+++ b/packages/enketo-express/public/js/src/module/gui.js
@@ -202,12 +202,14 @@ function feedback(message, duration, heading = t('feedback.header')) {
  * Shows a modal alert dialog.
  * TODO: parameters should change to (content, options)
  *
- * @param { string } message - message to show
+ * @param {string} message - message to show
  * @param {string=} heading - heading to show
  * @param {string=} level - css class or normal (no styling) ('alert', 'info', 'warning', 'error', 'success')
  * @param {number=} duration - duration in secondsafter which dialog should self-destruct
+ * @param {string=} buttonText - text for the button (default: OK)
+ * @returns {Promise} resolves when the alert is closed
  */
-function alert(message, heading, level, duration) {
+function alert(message, heading, level, duration, buttonText) {
     return new Promise((resolve) => {
         level = level || 'error';
         vex.closeAll();
@@ -217,7 +219,7 @@ function alert(message, heading, level, duration) {
             messageClassName: level === 'normal' ? '' : `alert-box ${level}`,
             buttons: [
                 {
-                    text: t('alert.validationsuccess.heading'),
+                    text: buttonText || t('alert.validationsuccess.heading'),
                     type: 'submit',
                     className: 'btn btn-primary small',
                 },


### PR DESCRIPTION
### 📣 Summary
This PR changes the button text for the initial background audio modal, making it clear for the user that upon clicking the button the recording will start.

### 💭 Notes
I have verified this PR works by manually testing (see CONTRIBUTING.md):

- [x] Online form submission
- [x] Offline form submission
- [x] Saving offline drafts
- [x] Loading offline drafts
- [x] Editing submissions
- [x] Form preview
- [ ] None of the above


### 👀 Preview steps
1. ℹ️ have an account and a project using background audio - ex. form: [bg-audio-form.xlsx](https://github.com/user-attachments/files/22629571/bg-audio-form.xlsx)
2. open form on enketo
4. 🔴 [on main] notice that the initial modal for background audio have a button with the text 'Ok'
5. 🟢 [on PR] notice that the button text changed to 'Ok, start recording'
