### PR TITLE
fix(backgroundAudio): form submission errors DEV-1135

### DIFF
--- a/packages/enketo-core/src/js/widget.js
+++ b/packages/enketo-core/src/js/widget.js
@@ -228,9 +228,7 @@ class Widget {
      */
     setValidationError(message) {
         if (!this.question) return;
-
         const errorMsgEl = this.question.querySelector('.custom-error-msg');
-
         if (message) {
             this.element.dataset.errorMessage = message;
             errorMsgEl.innerText = message;


### PR DESCRIPTION
### 🗒️ Checklist

- [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
- [x] assign yourself
- [x] fill in the template below and delete template comments
- [x] update all related docs (README, inline, etc.), if any
- [x] I have verified this PR works by manually testing (see CONTRIBUTING.md):
    - [x] Online form submission
    - [x] Offline form submission
    - [x] Saving offline drafts
    - [x] Loading offline drafts
    - [x] Editing submissions
    - [x] Form preview
    - [ ] None of the above
- [x] review thyself: read the diff and repro the preview as written
- [x] undraft PR & confirm that CI passes
- [x] request reviewers & improve according to review
- [ ] delete this section before merging


### 📣 Summary
Fix two submission errors on forms with background audio: one related to custom widget validation, and another for handling recordings that fail to start.


### 💭 Notes
- For the custom validation in widgets a new html element is introduced which is used to display an error, but that's not true for the background audio recording, being the exception, which has a different base structure and does not contain the custom error element. Bug introduced in #1444 
- When the recording did not start due to some issue, the `beforeSubmit` method was not validating if the recording was in progress to be able to stop it, generating an error.

### 👀 Preview steps
1. ℹ️ have an account and a project with a background audio recording question (e.g: [BackgroundAudio.xlsx](https://github.com/user-attachments/files/22745129/BackgroundAudio.xlsx))
2. open the form and try to submit the form
3. 🔴 [on main] notice that submission will fail
4. 🟢 [on PR] notice that the submission will go through properly
5. remove microphone permissions and reload the form
6. notice that there's a message about microphone not being available
7. try to submit the form
8. 🔴 [on main] an error will be displayed and submission will not happen
9. 🟢 [on PR] submission goes through without background audio data generated

