### PR TITLE
fix(multipageLayout): exclude background audio page DEV-1142

### DIFF
--- a/packages/enketo-core/src/js/page.js
+++ b/packages/enketo-core/src/js/page.js
@@ -9,6 +9,7 @@ import config from 'enketo/config';
 import events from './event';
 import { getSiblingElement, getAncestors } from './dom-utils';
 import 'jquery-touchswipe';
+import BackgroundAudioWidget from '../widget/background-audio/background-audio';
 
 /**
  * @typedef {import('./form').Form} Form
@@ -70,9 +71,7 @@ export default {
                         // Exclude background-audio widgets from being treated as pages
                         !(
                             el.matches('.question') &&
-                            el.querySelector(
-                                'input[data-background-audio="true"]'
-                            )
+                            el.querySelector(BackgroundAudioWidget.selector)
                         )
                 )
                 .map((el) => {


### PR DESCRIPTION
### 📣 Summary
This PR removes the blank first page created when a multi-page layout project has the background audio recording active.


### 👀 Preview steps
1. ℹ️ have an account and a multi page project with bg audio enabled (e.g: [bgAudioMultipage.xlsx](https://github.com/user-attachments/files/22789618/bgAudioMultipage.xlsx))
2. deploy and open the form
3. 🔴 [on main] the first page of the form is blank
4. 🟢 [on PR] the first page displays the first question of the project
