### PR TITLE
fix(repeating): autocomplete fails on repeating question DEV-1116

### DIFF
--- a/packages/enketo-core/src/js/itemset.js
+++ b/packages/enketo-core/src/js/itemset.js
@@ -209,14 +209,12 @@ export default {
                 '.itemset-labels'
             );
 
-            // Check if template exists before accessing its dataset
             if (!template) {
                 return;
             }
 
             const itemsXpath = template.dataset.itemsPath;
 
-            // Check if labelsContainer exists before accessing its dataset
             if (!labelsContainer) {
                 return;
             }
@@ -233,7 +231,6 @@ export default {
 
             const { valueRef } = labelsContainer.dataset;
 
-            // Shared datalists are under .or-repeat-info. Context is not relevant as these are static lists (without relative nodes).
             if (!input && !isShared) {
                 // No input element found, likely because repeat instances haven't been created yet
                 // This can happen with shared datalists in repeats during form initialization


### PR DESCRIPTION
### 🗒️ Checklist

- [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
- [x] assign yourself
- [x] fill in the template below and delete template comments
- [x] update all related docs (README, inline, etc.), if any
- [x] I have verified this PR works by manually testing (see CONTRIBUTING.md):
    - [x] Online form submission
    - [x] Offline form submission
    - [x] Saving offline drafts
    - [x] Loading offline drafts
    - [x] Editing submissions
    - [x] Form preview
    - [ ] None of the above
- [x] review thyself: read the diff and repro the preview as written
- [x] undraft PR & confirm that CI passes
- [ ] request reviewers & improve according to review
- [ ] delete this section before merging


### 📣 Summary
Fix autocomplete functionality failing in repeating questions during form initialization when repeat instances haven't been created yet.


### 💭 Notes
- Added defensive null checking for the `input` element parameter
- Implemented special handling for shared vs non-shared itemsets:
  - For **non-shared itemsets**: Early return if no input element exists (requires input context)
  - For **shared itemsets**: Allow processing without input context since they can be processed globally
- Set context to empty string when input element is not available, preventing undefined references

The fix resolves a timing issue where `itemset.update()` is called during form initialization before repeat instances are fully created. The autocomplete widget depends on itemsets, and when no input context is available:

- **Non-shared itemsets**: Require the specific input element context and should not proceed
- **Shared itemsets**: Can be processed without a specific input context since they apply globally


### 👀 Preview steps
1. ℹ️ have an account and
2. create a project with autocomplete inside a repeating question. e.g:  [Time-diary-Usage-Dare-to-Care_FAIL.xlsx](https://github.com/user-attachments/files/23444872/Time-diary-Usage-Dare-to-Care_FAIL.xlsx)
3. Deploy and open the form on Enketo
4. 🔴 [on main] notice that the form fails to load
5. 🟢 [on PR] notice that the form loads correctly and the autocomplete functionality works as intended.

