### PR TITLE
fix(security): sanitize media url parameter and reject attacks DEV-1249

### DIFF
--- a/packages/enketo-express/app/lib/media.js
+++ b/packages/enketo-express/app/lib/media.js
@@ -35,8 +35,8 @@ const matchMediaURLSegments = (requestPath) => {
     if (matches != null) {
         const [, resourceType, resourceId, hash, fileName] = matches;
 
-        // Sanitize fileName to prevent path traversal attacks
-        // Use path.normalize and path.basename to ensure only the filename is used
+        // Note: express is already normalizing URL's.
+        // Let's normalize them again for the sake of defense in depth.
         const sanitizedFileName = path.basename(path.normalize(fileName));
 
         // Reject if the normalized path differs significantly from the original
@@ -46,7 +46,7 @@ const matchMediaURLSegments = (requestPath) => {
             sanitizedFileName !== fileName ||
             /[/\\]|\.\.([/\\%]|%2F|%5C)/i.test(fileName)
         ) {
-            return;
+            throw new Error('Invalid file name in media URL');
         }
 
         return {


### PR DESCRIPTION
### 🗒️ Checklist

- [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
- [x] assign yourself
- [x] fill in the template below and delete template comments
- [x] update all related docs (README, inline, etc.), if any
- [x] I have verified this PR works by manually testing (see CONTRIBUTING.md):
    - [x] Online form submission
    - [x] Offline form submission
    - [x] Saving offline drafts
    - [x] Loading offline drafts
    - [x] Editing submissions
    - [x] Form preview
    - [x] None of the above
- [x] review thyself: read the diff and repro the preview as written
- [x] undraft PR & confirm that CI passes
- [ ] request reviewers & improve according to review
- [ ] delete this section before merging


### 📣 Summary
Implements sanitization and checks on Enketo's media endpoint to avoid path traversal attacks.

### 💭 Notes
**The Security Issue:**  Malicious paths get extracted and passed deeper into the system
Files like `../../../etc/passwd` could be used in cache keys, file operations, or logging

**Potential attack vectors:**

- Cache pollution: Malicious paths could corrupt cache keys
- Log injection: Dangerous paths could appear in logs
- Future vulnerabilities: If code later uses these filenames for file operations
- Information disclosure: Error messages might reveal file system structure

⚠️ **IMPORTANT!**

Even though we recognize the potential risks of the current implementation and the fix is being applied, this vulnerability couldn't be reproduced or explored in any of the theoretically known ways. 
Because of this there isn't a real "before" and "after" scenario to be tested, and the test was done by adding debugging into the code and checking if the mitigation mechanics were acting as expected, but none of those logs are present in this final version of the implementation.


### 👀 Preview steps
1. ℹ️ Run enketo express
2. run 
 ``` bash 
curl -v "http://ee.kobo.local/media/get/1/test/hash/../../../etc/passwd" 2>&1 | grep -E "(Record not present|Not found)"
```
3. 🔴 [on main] The malicious path is processed (checked via logs and debugging. See note above)
4. 🟢 [on PR]  The malicious path is rejected early (checked via logs and debugging. See note above)
