### PR TITLE
fix(enketo-core): show dynamic value in itemset label DEV-2001

### DIFF
--- a/packages/enketo-core/src/js/form.js
+++ b/packages/enketo-core/src/js/form.js
@@ -801,11 +801,15 @@ Form.prototype.getRelatedNodes = function (attr, filter, updated) {
         repeatControls = this.filterRadioCheckSiblings(controls);
     }
 
-    // If a new repeat was created, update the cached collection of all form controls with that attribute
-    // If a repeat was deleted (updated.repeatPath && !updated.cloned), rebuild cache.
-    // Exclude outputs from the cache, because outputs can be added via itemsets (in labels).
-    if (!this.all[attr] || (repeatPath && !cloned) || filter === '.or-output') {
-        // (re)build the cache
+    // Outputs can be dynamically added by itemsets (in labels), so always
+    // re-query the DOM to ensure cloned outputs are included.
+    if (filter === '.or-output') {
+        this.all[attr] = this.filterRadioCheckSiblings([
+            ...this.view.html.querySelectorAll(`[${attr}]`),
+        ]);
+    } else if (!this.all[attr] || (repeatPath && !cloned)) {
+        // If a new repeat was created, update the cached collection of all form controls with that attribute
+        // If a repeat was deleted (updated.repeatPath && !updated.cloned), rebuild cache.
         // However, if repeats have not been initialized exclude nodes inside a repeat until the first repeat has been added during repeat initialization.
         // The default view repeat will be removed during initialization (and stored as template), before it is re-added, if necessary.
         // We need to avoid adding these fields to the initial cache,

--- a/packages/enketo-core/test/forms/output-dynamic-itemset-no-repeat.xml
+++ b/packages/enketo-core/test/forms/output-dynamic-itemset-no-repeat.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms"
+        xmlns:odk="http://www.opendatakit.org/xforms" xmlns:cht="https://communityhealthtoolkit.org">
+  <h:head>
+    <h:title>Dynamic Choice Label</h:title>
+    <model odk:xforms-version="1.0.0">
+      <itext>
+        <translation lang="English (en)">
+          <text id="names-0">
+            <value>Mr.
+              <output value=" /data/name "/>
+            </value>
+          </text>
+          <text id="names-1">
+            <value>Mrs.
+              <output value=" /data/name "/>
+            </value>
+          </text>
+          <text id="/data/name:label">
+            <value>Name</value>
+          </text>
+          <text id="/data/select_name:label">
+            <value>Select Variant</value>
+          </text>
+        </translation>
+      </itext>
+      <instance>
+        <data id="dynamic_choice_label" version="20260320082937">
+          <name/>
+          <select_name/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </data>
+      </instance>
+      <instance id="names">
+        <root>
+          <item>
+            <itextId>names-0</itextId>
+            <name>mr</name>
+          </item>
+          <item>
+            <itextId>names-1</itextId>
+            <name>mrs</name>
+          </item>
+        </root>
+      </instance>
+      <bind nodeset="/data/name" type="string"/>
+      <bind nodeset="/data/select_name" type="string"/>
+      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
+    </model>
+  </h:head>
+  <h:body class="pages">
+    <input ref="/data/name">
+      <label ref="jr:itext('/data/name:label')"/>
+    </input>
+    <select1 ref="/data/select_name">
+      <label ref="jr:itext('/data/select_name:label')"/>
+      <itemset nodeset="instance('names')/root/item">
+        <value ref="name"/>
+        <label ref="jr:itext(itextId)"/>
+      </itemset>
+    </select1>
+  </h:body>
+</h:html>

--- a/packages/enketo-core/test/spec/itemset.spec.js
+++ b/packages/enketo-core/test/spec/itemset.spec.js
@@ -578,6 +578,25 @@ describe('Itemset functionality', () => {
             )[1];
             expect(option2.textContent.trim()).to.equal('#bb');
         });
+
+        it('populates outputs in generated option labels in forms without repeats', () => {
+            const form = loadForm('output-dynamic-itemset-no-repeat.xml');
+            form.init();
+
+            const nameInput = form.view.html.querySelector(
+                '[name="/data/name"]'
+            );
+            nameInput.value = 'John';
+            nameInput.dispatchEvent(events.Change());
+
+            const optionLabels = form.view.html.querySelectorAll(
+                '[data-name="/data/select_name"]+.option-label.active'
+            );
+
+            expect(optionLabels.length).to.equal(2);
+            expect(optionLabels[0].textContent).to.contain('John');
+            expect(optionLabels[1].textContent).to.contain('John');
+        });
     });
 
     describe('in a group that becomes relevant', () => {


### PR DESCRIPTION
### 🗒️ Checklist

- [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
- [ ] assign yourself
- [x] fill in the template below and delete template comments
- [x] update all related docs (README, inline, etc.), if any
- [x] I have verified this PR works by manually testing (see CONTRIBUTING.md):
    - [x] Online form submission
    - [x] Offline form submission
    - [ ] Saving offline drafts
    - [ ] Loading offline drafts
    - [ ] Editing submissions
    - [ ] Form preview
    - [ ] None of the above
- [x] review thyself: read the diff and repro the preview as written
- [x] undraft PR & confirm that CI passes
- [ ] request reviewers & improve according to review
- [ ] delete this section before merging


### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary, worded for non-technical seasoned Enketo end-users. -->
Fixes a bug where dynamic values in labels for `select` questions are sometimes not populated.


### 📖 Description
<!-- Delete this section if summary already said everything. -->
<!-- Full description, worded for non-technical seasoned Enketo end-users. -->
<!-- Examples:
- How does this change affect users?
- What are the intentional changes to behavior?
-->

For forms that used dynamic (interpolated) values in labels on the choices sheet (e.g. `Mr. ${name}`), these dynamic values are not populated when rendering the label (e.g. as an option on a `select_one/multiple` question) _unless the form also contained a `repeat`._    

You can reproduce the behavior on https://getodk.org/xlsform/ with a simple form like:

#### survey

type | name | label::en
-- | -- | --
text | name | Name
select_one names | select_name | Select Variant

#### choices 

list_name | name |label::en
-- | -- | --
names | mr | Mr. ${name}
names | mrs | Mrs. ${name}

#### Expected

<img width="466" height="274" alt="image" src="https://github.com/user-attachments/assets/adcececd-1484-4a4a-b2f3-c80c7ff3ffa1" />

#### Actual

<img width="466" height="274" alt="image" src="https://github.com/user-attachments/assets/58fdc583-1538-4093-a288-8794221f4c39" />

### 👷 Description for integrators
<!-- Delete this section if everything is already said above. -->
<!-- Full description, worded for technical Enketo integrators (Kobo, ODK, etc.). -->

The issue seems to be an incomplete implementation of a [this fix](https://github.com/enketo/enketo/commit/add50e136dd59e971bf01dc1b8df625067d7e75a#diff-608210f16bb20aa58380a2606ca9a842e85e4634d9e3d03347845848b9bc0f8c) which is trying to:

> Exclude outputs from the cache, because outputs can be added via itemsets (in labels).

Unfortunately, the ternary [on the next line](https://github.com/enketo/enketo/blob/2aab5ce716effe038fcc66041e4f16dbb908f26d/packages/enketo-core/src/js/form.js#L813) only actually busts the cache if `this.repeatsInitialized` is true.  When a form has dynamic values in the choice labels this produces additional `.or-output` items that are not included in `this.nonRepeats`. In that case we need to skip the cache and query the html directly which is what happens for forms _with a `repeat`_.  I am pretty sure it was just an oversight in the original changes that forms _without a `repeat`_ would still end up just referencing the cache for `.or-output` cases.

This PR simply updates the logic flow here to always skip the cache for `.or-output` (regardless of the `this.repeatsInitialized` value).

Template:
1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere BUT it should be here
5. 🟢 [on PR] notice that this is here
