### PR TITLE
fix(test): add cache model expiration tolerance in tests DEV-1931

### DIFF
--- a/packages/enketo-express/test/server/cache-model.spec.js
+++ b/packages/enketo-express/test/server/cache-model.spec.js
@@ -115,12 +115,15 @@ describe('Cache Model', () => {
                 .then(() => model.get(survey))
                 .then(() => getTtl('ca:testserver.com/bob,widgets'));
 
+            // We have 10ms tolerance here to account for the
+            // time it takes to execute the code in between and
+            // the variation expected in setTimeout.
             return Promise.all([
                 expect(promise1)
-                    .to.eventually.be.at.most(expiration - delayTime)
-                    .and.to.be.at.least(expiration - delayTime - 100),
+                    .to.eventually.be.at.most(expiration - delayTime + 10)
+                    .and.to.be.at.least(expiration - delayTime - 10),
                 expect(promise2)
-                    .to.eventually.be.at.most(expiration)
+                    .to.eventually.be.at.most(expiration + 10)
                     .and.to.be.at.least(expiration - 10),
             ]);
         });


### PR DESCRIPTION
### 💭 Notes
This fixes the cache-model test that keeps failing during CI.
The fail reason is that the test uses a `setTimeout` to check for the time elapsed, but due to nature of `setTimeout` we can have a small variation. That variation, usually 1 ms, is causing the test to fail.
I've added a 10 ms tolerance to the check, so the test will stop failing the CI process.


### 👀 Preview steps
Tests should stop failing frequently due to lack of tolerance in time verification.