### PR TITLE
ci: update checkout action to v6

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -15,7 +15,7 @@ jobs:
 
         steps:
             - name: Check out repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Log into registry ${{ env.REGISTRY }}
               uses: docker/login-action@v3

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -22,7 +22,7 @@ jobs:
           branch: ${{ github.ref_name }}
         steps:
             - name: Check out repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               
             - name: Set version information
               id: sha

--- a/.github/workflows/install-build-test.yml
+++ b/.github/workflows/install-build-test.yml
@@ -17,7 +17,7 @@ jobs:
             express: ${{ steps.changes.outputs.express }}
 
         steps:
-            - uses: 'actions/checkout@v3'
+            - uses: 'actions/checkout@v6'
             - uses: dorny/paths-filter@v2
               id: changes
               with:
@@ -46,7 +46,7 @@ jobs:
                 node-version: ['20.18.1', '22.12.0']
 
         steps:
-            - uses: 'actions/checkout@v3'
+            - uses: 'actions/checkout@v6'
 
             - uses: 'volta-cli/action@v4'
               with:
@@ -91,7 +91,7 @@ jobs:
                 node-version: ['22.12.0']
 
         steps:
-            - uses: 'actions/checkout@v3'
+            - uses: 'actions/checkout@v6'
 
             - uses: 'volta-cli/action@v4'
               with:
@@ -132,7 +132,7 @@ jobs:
                 node-version: ['22.12.0']
 
         steps:
-            - uses: 'actions/checkout@v3'
+            - uses: 'actions/checkout@v6'
 
             - uses: 'volta-cli/action@v4'
               with:
@@ -190,7 +190,7 @@ jobs:
                       browser: 'WebKit'
 
         steps:
-            - uses: 'actions/checkout@v3'
+            - uses: 'actions/checkout@v6'
 
             - uses: 'volta-cli/action@v4'
               with:
@@ -242,7 +242,7 @@ jobs:
                 node-version: ['22.12.0']
 
         steps:
-            - uses: 'actions/checkout@v3'
+            - uses: 'actions/checkout@v6'
 
             - uses: 'volta-cli/action@v4'
               with:
@@ -319,7 +319,7 @@ jobs:
                     - '6380:6379'
 
         steps:
-            - uses: 'actions/checkout@v3'
+            - uses: 'actions/checkout@v6'
 
             - uses: 'volta-cli/action@v4'
               with:


### PR DESCRIPTION
Per https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/, `actions/checkout` v3 and v4 are deprecated.

This commit removes one build warning from GitHub Actions:

	Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

More info at:

* v4:
  * https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4
  * https://github.com/actions/checkout/releases/tag/v4.0.0
* v5: https://github.com/actions/checkout?tab=readme-ov-file#checkout-v5
* v6: https://github.com/actions/checkout?tab=readme-ov-file#checkout-v6