### PR TITLE
feat(xml): strip invalid xml characters

### DIFF
--- a/packages/enketo-core/src/js/form.js
+++ b/packages/enketo-core/src/js/form.js
@@ -7,6 +7,7 @@ import {
     stripQuotes,
     getFilename,
     joinPath,
+    stripInvalidXmlCharacters,
 } from './utils';
 import {
     getXPath,
@@ -1058,6 +1059,29 @@ Form.prototype.setEventHandlers = function () {
 
     // Prevent default submission, e.g. when text field is filled in and Enter key is pressed
     this.view.$.attr('onsubmit', 'return false;');
+
+    // Strip invalid XML characters from pasted text in input fields and textareas
+    this.view.html.addEventListener('paste', (event) => {
+        const el = event.target;
+        if (
+            el.matches &&
+            el.matches(
+                'input:not(.ignore):not([type="file"]), textarea:not(.ignore)'
+            )
+        ) {
+            const pasteData = event.clipboardData
+                ? event.clipboardData.getData('text')
+                : null;
+            if (
+                pasteData &&
+                pasteData !== stripInvalidXmlCharacters(pasteData)
+            ) {
+                event.preventDefault();
+                const sanitized = stripInvalidXmlCharacters(pasteData);
+                document.execCommand('insertText', false, sanitized);
+            }
+        }
+    });
 
     /*
      * The listener below catches both change and change.file events.

--- a/packages/enketo-core/src/js/nodeset.js
+++ b/packages/enketo-core/src/js/nodeset.js
@@ -3,6 +3,7 @@ import types from './types';
 import event from './event';
 import { getXPath } from './dom-utils';
 import { isNodeRelevant, setNonRelevantValue } from './relevant';
+import { stripInvalidXmlCharacters } from './utils';
 
 /**
  * @typedef NodesetFilter
@@ -119,6 +120,7 @@ Nodeset.prototype.setVal = function (newVals, xmlDataType) {
         newVal = '';
     }
 
+    newVal = stripInvalidXmlCharacters(newVal);
     newVal = this.convert(newVal, xmlDataType);
 
     const strVal = String(newVal);

--- a/packages/enketo-core/src/js/utils.js
+++ b/packages/enketo-core/src/js/utils.js
@@ -163,12 +163,40 @@ function dataUriToBlobSync(dataURI) {
 }
 
 /**
+ * Regex matching characters that are not valid in XML 1.0.
+ *
+ * @see https://www.w3.org/TR/REC-xml/#charsets
+ * @type {RegExp}
+ */
+const INVALID_XML_CHARS =
+    /[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/gu;
+
+/**
+ * Strips characters that are not valid in XML 1.0.
+ *
+ * @static
+ * @param {string} str - The string to sanitize
+ * @return {string} The sanitized string with invalid XML characters removed
+ */
+function stripInvalidXmlCharacters(str) {
+    if (!str) {
+        return str;
+    }
+
+    return str.replace(INVALID_XML_CHARS, '');
+}
+
+/**
  * @static
  * @param {Event} event - a paste event
  * @return {string|null} clipboard data text value contained in event or null
  */
 function getPasteData(event) {
-    return event.clipboardData ? event.clipboardData.getData('text') : null;
+    const data = event.clipboardData
+        ? event.clipboardData.getData('text')
+        : null;
+
+    return data ? stripInvalidXmlCharacters(data) : data;
 }
 
 /**
@@ -338,6 +366,7 @@ export {
     readCookie,
     dataUriToBlobSync,
     getPasteData,
+    stripInvalidXmlCharacters,
     resizeImage,
     joinPath,
     getScript,

--- a/packages/enketo-core/src/js/utils.js
+++ b/packages/enketo-core/src/js/utils.js
@@ -168,8 +168,8 @@ function dataUriToBlobSync(dataURI) {
  * @see https://www.w3.org/TR/REC-xml/#charsets
  * @type {RegExp}
  */
-// eslint-disable-next-line no-control-regex, no-misleading-character-class
 const INVALID_XML_CHARS =
+    // eslint-disable-next-line no-control-regex, no-misleading-character-class
     /[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/gu;
 
 /**

--- a/packages/enketo-core/src/js/utils.js
+++ b/packages/enketo-core/src/js/utils.js
@@ -168,6 +168,7 @@ function dataUriToBlobSync(dataURI) {
  * @see https://www.w3.org/TR/REC-xml/#charsets
  * @type {RegExp}
  */
+// eslint-disable-next-line no-control-regex, no-misleading-character-class
 const INVALID_XML_CHARS =
     /[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u{10000}-\u{10FFFF}]/gu;
 

--- a/packages/enketo-core/test/spec/utils.spec.js
+++ b/packages/enketo-core/test/spec/utils.spec.js
@@ -216,3 +216,77 @@ describe('SVG Sanitization', () => {
         expect(utils.sanitizeSvg(undefined)).to.be.undefined;
     });
 });
+
+describe('stripInvalidXmlCharacters', () => {
+    it('should return the same string when no invalid characters are present', () => {
+        expect(utils.stripInvalidXmlCharacters('hello world')).to.equal(
+            'hello world'
+        );
+    });
+
+    it('should preserve valid XML whitespace characters (tab, LF, CR)', () => {
+        expect(utils.stripInvalidXmlCharacters('a\tb\nc\rd')).to.equal(
+            'a\tb\nc\rd'
+        );
+    });
+
+    it('should strip null character (U+0000)', () => {
+        expect(utils.stripInvalidXmlCharacters('ab\x00cd')).to.equal('abcd');
+    });
+
+    it('should strip control characters U+0001 through U+0008', () => {
+        expect(
+            utils.stripInvalidXmlCharacters(
+                'a\x01\x02\x03\x04\x05\x06\x07\x08b'
+            )
+        ).to.equal('ab');
+    });
+
+    it('should strip U+000B (vertical tab) and U+000C (form feed)', () => {
+        expect(utils.stripInvalidXmlCharacters('a\x0B\x0Cb')).to.equal('ab');
+    });
+
+    it('should strip control characters U+000E through U+001F', () => {
+        expect(utils.stripInvalidXmlCharacters('a\x0E\x0F\x10\x1F b')).to.equal(
+            'a b'
+        );
+    });
+
+    it('should strip U+FFFE and U+FFFF', () => {
+        expect(utils.stripInvalidXmlCharacters('a\uFFFE\uFFFFb')).to.equal(
+            'ab'
+        );
+    });
+
+    it('should preserve valid characters in the range U+0020 to U+D7FF', () => {
+        expect(
+            utils.stripInvalidXmlCharacters('Hello! @#$%^&*() é ñ ü')
+        ).to.equal('Hello! @#$%^&*() é ñ ü');
+    });
+
+    it('should preserve valid characters in the range U+E000 to U+FFFD', () => {
+        expect(utils.stripInvalidXmlCharacters('\uE000\uFFFD')).to.equal(
+            '\uE000\uFFFD'
+        );
+    });
+
+    it('should preserve valid supplementary characters (U+10000 to U+10FFFF)', () => {
+        // U+1F600 is 😀 (grinning face emoji)
+        expect(utils.stripInvalidXmlCharacters('hello 😀')).to.equal(
+            'hello 😀'
+        );
+    });
+
+    it('should return falsy values as-is', () => {
+        expect(utils.stripInvalidXmlCharacters('')).to.equal('');
+        expect(utils.stripInvalidXmlCharacters(null)).to.equal(null);
+        expect(utils.stripInvalidXmlCharacters(undefined)).to.equal(undefined);
+    });
+
+    it('should strip mixed invalid characters from a realistic string', () => {
+        // Simulates copy-paste from a bad PDF containing U+0000 and U+0002
+        expect(
+            utils.stripInvalidXmlCharacters('Patient\x00 name:\x02 John Doe')
+        ).to.equal('Patient name: John Doe');
+    });
+});


### PR DESCRIPTION
### 📣 Summary

Enketo now strips invalid XML characters when pasting text into form fields, preventing failures when loading drafts or editing submissions that previously contained such characters.

### 📖 Description

When copy-pasting text from sources like poorly formatted PDFs, invisible control characters could end up in form responses. Enketo would accept and submit these characters, but then fail to reload those responses as drafts or for editing. This change ensures invalid XML characters are silently removed on paste, so they never make it into a submission.

### 💭 Notes

- This is a prerequisite for DEV-1129 (rejecting submissions with invalid XML characters on the KPI side). Once this change is deployed, KPI can safely start rejecting such submissions.
- The `document.execCommand('insertText')` approach is used for the paste interception to preserve undo history in the browser.
- 11 unit tests were added covering null chars, control characters, valid whitespace preservation, BMP/SMP ranges, emoji, and realistic bad-PDF scenarios.
Characters outside the [valid XML 1.0 range](https://www.w3.org/TR/REC-xml/#charsets) (`#x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]`) are now stripped at three layers in enketo-core:

1. **Paste interception** (`form.js`) — A form-level `paste` event listener on text `<input>` and `<textarea>` elements prevents invalid characters from entering the UI.
2. **`getPasteData()` utility** (`utils.js`) — Widgets using this helper (e.g. the datepicker) automatically receive sanitized clipboard data.
3. **Model-level safety net** (`nodeset.js`) — `Nodeset.prototype.setVal()` strips invalid characters before writing to the XML model, guarding against any input path that bypasses the paste listener.

A new `stripInvalidXmlCharacters()` utility function is exported from `utils.js` for use by integrators if needed.


### 👀 Preview steps

1. ℹ️ have an account and a project with a form containing a text or textarea field
2. copy text containing invisible control characters (e.g. from a badly formatted PDF, or use this command on console: `copy("Hello\x00 from\x01 a\x02 bad\x0B PDF\x0C file\x1F!")`)
3. paste it into a text field in the Enketo form
4. 🔴 [on main] the invalid characters are silently accepted; submitting the form and then trying to edit the submission fails with an XML parse error
5. 🟢 [on PR] the invalid characters are stripped on paste; the submitted data contains only valid XML characters, and editing the submission works correctly