### PR TITLE
fix(FormModel): prevent session creation if model is invalid DEV-1945

### DIFF
--- a/packages/enketo-core/src/js/form-model.js
+++ b/packages/enketo-core/src/js/form-model.js
@@ -259,6 +259,10 @@ FormModel.prototype.createSession = function (id, sessObj) {
     let instance;
     let session;
     const model = this.xml.querySelector('model');
+    if (!model || model !== this.xml.documentElement) {
+        return;
+    }
+
     const fixedProps = [
         'deviceid',
         'username',
@@ -267,9 +271,6 @@ FormModel.prototype.createSession = function (id, sessObj) {
         'simserial',
         'subscriberid',
     ];
-    if (!model) {
-        return;
-    }
 
     sessObj = typeof sessObj === 'object' ? sessObj : {};
     instance = model.querySelector(`instance#${CSS.escape(id)}`);


### PR DESCRIPTION
### 📣 Summary

Forms with a field named `model` no longer break the session context used for preloads like `username`, `deviceid`, etc.


### 💭 Notes

When a form contained a field named `model`, `querySelector('model')` in `createSession` would match that data field instead of the actual `<model>` root element. This caused the session instance — which populates preload values like `username`, `deviceid`, `phonenumber`, etc. — to be appended to the wrong node, corrupting the form instance.

The fix adds a guard to ensure the matched element is actually the document root (`=== this.xml.documentElement`) before proceeding. This also correctly prevents `createSession` from running on the `FormModel` clone used in `getDataStrWithoutIrrelevantNodes`, which is initialized from instance data (not model XML) and does not need a session.

- `createSession` is called once from `init`, but `FormModel` can be instantiated a second time as a clone via `new FormModel(this.model.getStr())` in `Form.prototype.getDataStrWithoutIrrelevantNodes`. In that case, `modelStr` is the serialized primary instance child (e.g. `<data>...</data>`), not the full model XML — so `documentElement` is never `<model>` and the guard correctly skips session creation.
- The transformer (`openrosa2xmlmodel.xsl` via `docToString`) always produces `<model>...</model>` as the root of `modelStr` for a real form, so the guard never incorrectly blocks the legitimate path.


### 👀 Preview steps

1. Create a form with a field named `model`.
2. Load the form.
3. On main: Notice that the submission fails with an error
4. On branch: Verify that the form submits successfully.