### PR TITLE
feat(singleSubmission): add full-screen custom submission messages DEV-1114

### DIFF
--- a/packages/enketo-express/app/views/styles/common.scss
+++ b/packages/enketo-express/app/views/styles/common.scss
@@ -67,3 +67,36 @@ progress {
 .log {
     word-break: break-all;
 }
+
+.vex.vex-theme-plain.full-screen {
+    padding: 0;
+
+    .vex-content {
+        width: 100vw; // fallback for browsers without dvw support
+        width: 100dvw; // dynamic viewport: accounts for mobile browser UI
+        min-height: 100vh; // fallback for browsers without dvh support
+        min-height: 100dvh; // dynamic viewport: accounts for mobile browser UI
+        border: none;
+        border-radius: 0;
+    }
+
+    .vex-dialog-message {
+        border: 7px solid #ddd;
+        border-radius: 7px;
+        padding: 1em 3em;
+        margin: 1em 3em;
+    }
+
+    .vex-dialog-title {
+        // visually hidden but available to assistive technologies
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border-width: 0;
+    }
+}

--- a/packages/enketo-express/package.json
+++ b/packages/enketo-express/package.json
@@ -47,6 +47,7 @@
         "jquery": "3.6.3",
         "jstransformer-markdown-it": "^3.0.0",
         "jszip": "^3.10.1",
+        "markdown-it": "^13.0.2",
         "jwt-simple": "^0.5.6",
         "libxslt": "0.10.2",
         "load-grunt-tasks": "^5.1.0",

--- a/packages/enketo-express/public/js/src/module/connection.js
+++ b/packages/enketo-express/public/js/src/module/connection.js
@@ -165,29 +165,25 @@ function _uploadBatch(recordBatch) {
                 message: undefined,
             };
 
-            // Note: OpenRosa servers return 201 or 202 status codes upon successful submission.
-            if (response.status !== 201 && response.status !== 202) {
-                return response.text().then((text) => {
-                    const xmlResponse = parser.parseFromString(
-                        text,
-                        'text/xml'
+            return response.text().then((text) => {
+                const xmlResponse = parser.parseFromString(text, 'text/xml');
+                if (xmlResponse) {
+                    const messageEl = xmlResponse.querySelector(
+                        'OpenRosaResponse > message'
                     );
-                    if (xmlResponse) {
-                        const messageEl = xmlResponse.querySelector(
-                            'OpenRosaResponse > message'
-                        );
-                        if (messageEl) {
-                            result.message = messageEl.textContent;
-                        } else {
-                            result.message = text;
-                        }
-                    } else {
+                    if (messageEl) {
+                        result.message = messageEl.textContent;
+                    }
+                }
+                // Note: OpenRosa servers return 201 or 202 status codes upon successful submission.
+                if (response.status !== 201 && response.status !== 202) {
+                    if (!result.message) {
                         result.message = text;
                     }
                     throw result;
-                });
-            }
-            return result;
+                }
+                return result;
+            });
         })
         .catch((error) => {
             if (

--- a/packages/enketo-express/public/js/src/module/connection.js
+++ b/packages/enketo-express/public/js/src/module/connection.js
@@ -165,14 +165,25 @@ function _uploadBatch(recordBatch) {
                 message: undefined,
             };
 
-            return response.text().then((text) => {
-                const xmlResponse = parser.parseFromString(text, 'text/xml');
-                if (xmlResponse) {
-                    const messageEl = xmlResponse.querySelector(
-                        'OpenRosaResponse > message'
+            // safeguard for response.text() not being a function/not existing (e.g. in some test environments)
+            const textPromise =
+                typeof response.text === 'function'
+                    ? response.text()
+                    : Promise.resolve('');
+
+            return textPromise.then((text) => {
+                if (text) {
+                    const xmlResponse = parser.parseFromString(
+                        text,
+                        'text/xml'
                     );
-                    if (messageEl) {
-                        result.message = messageEl.textContent;
+                    if (xmlResponse) {
+                        const messageEl = xmlResponse.querySelector(
+                            'OpenRosaResponse > message'
+                        );
+                        if (messageEl) {
+                            result.message = messageEl.textContent;
+                        }
                     }
                 }
                 // Note: OpenRosa servers return 201 or 202 status codes upon successful submission.

--- a/packages/enketo-express/public/js/src/module/controller-webform.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform.js
@@ -413,9 +413,8 @@ function _submitRecord(survey) {
             // this event is used in communicating back to iframe parent window
             document.dispatchEvent(events.SubmissionSuccess());
 
-            const submitMessage = submitMessageXPath
-                ? form.model.node(submitMessageXPath).getVal()
-                : null;
+            // Only check for result message if there was a submitMessageXPath defined
+            const submitMessage = submitMessageXPath ? result.message : null;
 
             if (
                 settings.type === 'single' &&

--- a/packages/enketo-express/public/js/src/module/controller-webform.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform.js
@@ -356,7 +356,7 @@ function _submitRecord(survey) {
     let msg = '';
     const include = { irrelevant: false };
 
-    const hasSubmitMessage = getSubmitMessage() !== null;
+    const submitMessageXPath = getSubmitMessageXPath();
 
     form.view.html.dispatchEvent(events.BeforeSave());
 
@@ -413,15 +413,18 @@ function _submitRecord(survey) {
             // this event is used in communicating back to iframe parent window
             document.dispatchEvent(events.SubmissionSuccess());
 
+            const submitMessage = submitMessageXPath
+                ? form.model.node(submitMessageXPath).getVal()
+                : null;
+
             if (
                 settings.type === 'single' &&
-                hasSubmitMessage &&
-                result.message &&
-                result.message.length > 0
+                submitMessage &&
+                submitMessage.length > 0
             ) {
                 const md = markdownit();
                 gui.fullScreenAlert(
-                    md.render(result.message),
+                    md.render(submitMessage),
                     t('alert.submissionsuccess.heading'),
                     'normal'
                 );
@@ -919,11 +922,17 @@ function setLogoutLinkVisibility() {
     $('.form-footer .logout').toggleClass('hide', !visible);
 }
 
-function getSubmitMessage() {
+function getSubmitMessageXPath() {
     const xmlParser = new DOMParser();
     const xmlForm = xmlParser.parseFromString(formData.modelStr, 'text/xml');
+    const dataEl = xmlForm.querySelector('model > instance > data');
 
-    return xmlForm.querySelector('submitMessage');
+    return dataEl
+        ? dataEl.getAttributeNS(
+              'http://kobotoolbox.org/xforms',
+              'submitMessage'
+          )
+        : null;
 }
 
 /**

--- a/packages/enketo-express/public/js/src/module/controller-webform.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform.js
@@ -21,6 +21,7 @@ import encryptor from './encryptor';
 import formCache from './form-cache';
 import { getLastSavedRecord, populateLastSavedInstances } from './last-saved';
 import { replaceMediaSources, replaceModelMediaSources } from './media';
+import markdownit from 'markdown-it';
 
 /**
  * @typedef {import('../../../../app/models/survey-model').SurveyObject} Survey
@@ -355,6 +356,8 @@ function _submitRecord(survey) {
     let msg = '';
     const include = { irrelevant: false };
 
+    const hasSubmitMessage = getSubmitMessage() !== null;
+
     form.view.html.dispatchEvent(events.BeforeSave());
 
     beforeMsg = redirect ? t('alert.submission.redirectmsg') : '';
@@ -403,10 +406,29 @@ function _submitRecord(survey) {
                 })}<br/>`;
                 level = 'warning';
             }
+
+            return result;
         })
-        .then(() => {
+        .then((result) => {
             // this event is used in communicating back to iframe parent window
             document.dispatchEvent(events.SubmissionSuccess());
+
+            if (
+                settings.type === 'single' &&
+                hasSubmitMessage &&
+                result.message &&
+                result.message.length > 0
+            ) {
+                const md = markdownit();
+                gui.fullScreenAlert(
+                    md.render(result.message),
+                    t('alert.submissionsuccess.heading'),
+                    'normal'
+                );
+                _resetForm(survey);
+
+                return;
+            }
 
             if (redirect) {
                 if (!settings.multipleAllowed) {
@@ -895,6 +917,13 @@ function setLogoutLinkVisibility() {
         .split('; ')
         .some((rawCookie) => rawCookie.indexOf('__enketo_logout=') !== -1);
     $('.form-footer .logout').toggleClass('hide', !visible);
+}
+
+function getSubmitMessage() {
+    const xmlParser = new DOMParser();
+    const xmlForm = xmlParser.parseFromString(formData.modelStr, 'text/xml');
+
+    return xmlForm.querySelector('submitMessage');
 }
 
 /**

--- a/packages/enketo-express/public/js/src/module/gui.js
+++ b/packages/enketo-express/public/js/src/module/gui.js
@@ -238,6 +238,41 @@ function alert(
 }
 
 /**
+ * Shows a full-screen modal alert.
+ * Intended for custom form submission confirmation messages.
+ *
+ * @param {string} message - message to show (HTML)
+ * @param {string=} heading - heading (visually hidden, available to assistive technologies)
+ * @param {string=} level - css class ('alert', 'info', 'warning', 'error', 'success')
+ * @param {boolean} [dismissible=false] - whether the dialog can be dismissed via button, X, or ESC
+ * @returns {Promise} resolves when the alert is closed
+ */
+function fullScreenAlert(message, heading, level, dismissible = false) {
+    return new Promise((resolve) => {
+        level = level || 'error';
+        vex.closeAll();
+        vex.dialog.alert({
+            className: 'vex-theme-plain full-screen',
+            unsafeMessage: `<span>${message}</span>`,
+            title: heading || t('alert.default.heading'),
+            messageClassName: level === 'normal' ? '' : `alert-box ${level}`,
+            buttons: dismissible
+                ? [
+                      {
+                          text: t('alert.default.button'),
+                          type: 'submit',
+                          className: 'btn btn-primary small',
+                      },
+                  ]
+                : [],
+            showCloseButton: dismissible,
+            escapeButtonCloses: dismissible,
+            afterClose: resolve,
+        });
+    });
+}
+
+/**
  * Shows a confirmation dialog
  *
  * @param {?(object.<string, (string|boolean)>|string)=} content - In its simplest form this is just a string but it can
@@ -675,6 +710,7 @@ $(document).ready(() => {
 
 export default {
     alert,
+    fullScreenAlert,
     confirm,
     prompt,
     feedback,


### PR DESCRIPTION
### 📣 Summary

Forms can now display a server-provided confirmation message after successful single-submission, rendered as Markdown in a full-screen modal.

### 📖 Description

When a form's model contains a `<submitMessage>` element and an OpenRosa server responds to a submission with a `<message>` element inside `<OpenRosaResponse>`, Enketo now displays that message to the respondent as a full-screen, non-dismissible modal instead of the default redirect/success dialog.

The message supports Markdown formatting (rendered client-side via `markdown-it`). Only single-submission forms (`/single/` URL) are eligible.

### 💭 Notes

- Re-implementation of #1368 (`boazsender-custom-confirmation-message`). That PR was authored by @boazsender but was never merged. This implementation takes a cleaner approach: `markdown-it` is used directly (the original PR used `jstransformer-markdown-it` which is Node.js-only and would not have bundled correctly for the browser), and the `<submitMessage>` opt-in check is isolated in a `getSubmitMessage()` helper rather than threaded as a parameter through the submit stack.
- `connection.js` was refactored to always parse the OpenRosa XML response body — not only on errors — so `result.message` is available on success (201/202) as well.
- A new `gui.fullScreenAlert(message, heading, level, dismissible)` function is exposed for potential reuse.
- The full-screen modal uses `vex-js` with `escapeButtonCloses: false` and no buttons by default, making it truly non-dismissible. A `dismissible` parameter exists for future use.
- The `.vex-dialog-title` is visually hidden but available to assistive technologies (sr-only pattern).
- Regression risk: the `connection.js` change means `response.text()` is now always consumed on upload responses. This should be safe since the body is only read once, but any downstream fork that relied on the response body being unconsumed on success paths should be aware.

The feature requires two conditions to be met:

1. **Client-side opt-in**: the form's model XML must contain a `<submitMessage>` element. Forms without this element continue to behave as before.
2. **Server response**: the OpenRosa server must return a non-empty `<OpenRosaResponse><message>` body on a successful (201/202) submission response.


### 👀 Preview steps

1. ℹ️ Have a form prepared for submission custom  response (e.g: 
[SubmitMessage-Basic.xlsx](https://github.com/user-attachments/files/26841070/SubmitMessage-Basic.xlsx)
[SubmitMessage-jrchoicename.xlsx](https://github.com/user-attachments/files/26841072/SubmitMessage-jrchoicename.xlsx)
[SubmitMessageLocalized.xlsx](https://github.com/user-attachments/files/26841073/SubmitMessageLocalized.xlsx))
2. Open a form in online mode and `single` or `once per responder` mode
3. Fill out and submit the form.
4. 🔴 [on main] After submission, the standard redirect/success dialog appears.
5. 🟢 [on PR] After submission, a full-screen modal displays the server's response message rendered as Markdown.
6. Verify the modal cannot be dismissed via button, close icon, or ESC key.

8. ℹ️ Submit a form **without** `<submitMessage>` in the model — confirm the standard behavior is unchanged.