### PR TITLE
feat(gui): restyle custom confirmation message  DEV-2019

### DIFF
--- a/packages/enketo-express/public/js/src/module/controller-webform.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform.js
@@ -21,7 +21,6 @@ import encryptor from './encryptor';
 import formCache from './form-cache';
 import { getLastSavedRecord, populateLastSavedInstances } from './last-saved';
 import { replaceMediaSources, replaceModelMediaSources } from './media';
-import markdownit from 'markdown-it';
 
 /**
  * @typedef {import('../../../../app/models/survey-model').SurveyObject} Survey
@@ -413,7 +412,7 @@ function _submitRecord(survey) {
             // this event is used in communicating back to iframe parent window
             document.dispatchEvent(events.SubmissionSuccess());
 
-            // Only check for result message if there was a submitMessageXPath defined
+            // Only consider result message if there was a submitMessageXPath defined
             const submitMessage = submitMessageXPath ? result.message : null;
 
             if (
@@ -421,13 +420,7 @@ function _submitRecord(survey) {
                 submitMessage &&
                 submitMessage.length > 0
             ) {
-                const md = markdownit();
-                gui.fullScreenAlert(
-                    md.render(submitMessage),
-                    t('alert.submissionsuccess.heading'),
-                    'normal'
-                );
-                _resetForm(survey);
+                gui.displayMessageInForm(submitMessage);
 
                 return;
             }

--- a/packages/enketo-express/public/js/src/module/gui.js
+++ b/packages/enketo-express/public/js/src/module/gui.js
@@ -7,6 +7,7 @@ import support from 'enketo-core/src/js/support';
 import * as printHelper from 'enketo-core/src/js/print';
 import vex from 'vex-js';
 import $ from 'jquery';
+import markdownit from 'markdown-it';
 import vexEnketoDialog from 'vex-dialog-enketo';
 import feedbackBar from './feedback-bar';
 import settings from './settings';
@@ -708,6 +709,47 @@ $(document).ready(() => {
     init();
 });
 
+/**
+ * Replaces the form content with the given HTML element, keeping the
+ * surrounding layout (header, footer) intact. Footer action buttons are
+ * removed, leaving only the "powered by" branding.
+ *
+ * Attention: This is a destructive action, intended for use after a form submission,
+ * in single mode, when the form content is no longer needed.
+ *
+ * @param {string} markdown - the message to render
+ */
+function displayMessageInForm(markdown) {
+    const md = markdownit();
+    const msgEl = document.createElement('div');
+    msgEl.className = 'in-form-message';
+    msgEl.innerHTML = md.render(markdown);
+
+    const formEl = document.querySelector('form.or');
+    if (!formEl) {
+        return;
+    }
+    vex.closeAll();
+
+    formEl.replaceChildren(msgEl);
+
+    // Hide buttons from the footer, but keep the "powered by" branding.
+    const mainControls = document.querySelector(
+        '.form-footer__content__main-controls'
+    );
+    const enketoPower = mainControls
+        ? mainControls.querySelector('.enketo-power')
+        : null;
+    if (mainControls) {
+        mainControls.replaceChildren(...(enketoPower ? [enketoPower] : []));
+    }
+
+    const jumpNav = document.querySelector('.form-footer__content__jump-nav');
+    if (jumpNav) {
+        jumpNav.hidden = true;
+    }
+}
+
 export default {
     alert,
     fullScreenAlert,
@@ -724,4 +766,5 @@ export default {
     applyPrintStyle,
     getPrintDialogComponents,
     printForm,
+    displayMessageInForm,
 };

--- a/packages/enketo-express/public/js/src/module/gui.js
+++ b/packages/enketo-express/public/js/src/module/gui.js
@@ -239,41 +239,6 @@ function alert(
 }
 
 /**
- * Shows a full-screen modal alert.
- * Intended for custom form submission confirmation messages.
- *
- * @param {string} message - message to show (HTML)
- * @param {string=} heading - heading (visually hidden, available to assistive technologies)
- * @param {string=} level - css class ('alert', 'info', 'warning', 'error', 'success')
- * @param {boolean} [dismissible=false] - whether the dialog can be dismissed via button, X, or ESC
- * @returns {Promise} resolves when the alert is closed
- */
-function fullScreenAlert(message, heading, level, dismissible = false) {
-    return new Promise((resolve) => {
-        level = level || 'error';
-        vex.closeAll();
-        vex.dialog.alert({
-            className: 'vex-theme-plain full-screen',
-            unsafeMessage: `<span>${message}</span>`,
-            title: heading || t('alert.default.heading'),
-            messageClassName: level === 'normal' ? '' : `alert-box ${level}`,
-            buttons: dismissible
-                ? [
-                      {
-                          text: t('alert.default.button'),
-                          type: 'submit',
-                          className: 'btn btn-primary small',
-                      },
-                  ]
-                : [],
-            showCloseButton: dismissible,
-            escapeButtonCloses: dismissible,
-            afterClose: resolve,
-        });
-    });
-}
-
-/**
  * Shows a confirmation dialog
  *
  * @param {?(object.<string, (string|boolean)>|string)=} content - In its simplest form this is just a string but it can
@@ -752,7 +717,6 @@ function displayMessageInForm(markdown) {
 
 export default {
     alert,
-    fullScreenAlert,
     confirm,
     prompt,
     feedback,


### PR DESCRIPTION
### 📣 Summary

When a form defines a custom submission message, it now appears inline within the form page instead of in a full-screen overlay.

### 💭 Notes

- Forms that include a `kobo:submitMessage` attribute in their model can define a custom message to show after a successful submission. Previously, this message was displayed in a full-screen modal dialog (using `fullScreenAlert`). With this change, the message is rendered inline — the form content is replaced with the message in place, while the page header and footer remain visible.
- Footer action buttons (Submit, Save Draft, etc.) are removed once the message is shown, since there is nothing more to do.

### 👀 Preview steps

1. ℹ️ Have a form with `kobo:submitMessage` configures. e.g: [SubmitMessage-Basic.xlsx](https://github.com/user-attachments/files/27061604/SubmitMessage-Basic.xlsx)
2. Open the form in single-submission mode.
3. Fill in and submit the form.
4. 🔴 [on main] Notice a full-screen overlay appears with the custom message, blocking the entire page.
5. 🟢 [on PR] Notice the form content is replaced by the custom message inline, with the form header and "powered by" footer still visible and the action buttons gone.

This form: [SubmitMessageMultilineText.xlsx](https://github.com/user-attachments/files/27061639/SubmitMessageMultilineText.xlsx) can also be good for testing, since it uses a multiline text box as the input for the confirmation message, allowing for testing long markdown formatted strings, e.g: 

```
#### Thank you for your submission!

Your response has been recorded. A member of our team will review it shortly.

If you have any questions, please contact [support@example.org](mailto:support@example.org).
```

<img width="888" height="937" alt="Screenshot from 2026-04-24 13-00-37" src="https://github.com/user-attachments/assets/62a342d3-832d-47a6-8844-f5cd3962c7cb" />
