### PR TITLE
fix(security): ensure default params can't target unexpected form elements DEV-2136

### DIFF
--- a/packages/enketo-express/public/js/src/enketo-webform.js
+++ b/packages/enketo-express/public/js/src/enketo-webform.js
@@ -222,7 +222,23 @@ function _swapTheme(survey) {
     return Promise.reject(new Error('Received form incomplete'));
 }
 
-function _prepareInstance(modelStr, defaults) {
+// Standard ODK metadata fields that must not be pre-populated via URL defaults.
+// https://getodk.github.io/xforms-spec/#metadata
+const PROTECTED_META_FIELDS = new Set([
+    'instanceID',
+    'instanceName',
+    'timeStart',
+    'timeEnd',
+    'today',
+    'userID',
+    'deviceID',
+    'deprecatedID',
+    'email',
+    'phoneNumber',
+    'audit',
+]);
+
+export function _prepareInstance(modelStr, defaults) {
     let model;
     let init;
     let existingInstance = null;
@@ -235,10 +251,34 @@ function _prepareInstance(modelStr, defaults) {
                     full: false,
                 });
             init = init || model.init();
-            if (Object.prototype.hasOwnProperty.call(defaults, path)) {
-                // if this fails, the FormModel will output a console error and ignore the instruction
-                model.node(path).setVal(defaults[path]);
+            // Defaults should not target attributes
+            if (path.includes('@')) {
+                continue;
             }
+            const targetNode = model.node(path).getElement();
+            // Must resolve to a node strictly inside the primary instance root
+            if (
+                !targetNode ||
+                !model.rootElement.contains(targetNode) ||
+                targetNode === model.rootElement
+            ) {
+                continue;
+            }
+            // Defaults should not target groups, only leaf fields
+            if (targetNode.children.length > 0) {
+                continue;
+            }
+            // Standard ODK metadata fields must not be overridden
+            const metaEl = model.rootElement.querySelector(':scope > meta');
+            if (
+                metaEl &&
+                metaEl.contains(targetNode) &&
+                PROTECTED_META_FIELDS.has(targetNode.localName)
+            ) {
+                continue;
+            }
+            // if this fails, the FormModel will output a console error and ignore the instruction
+            model.node(path).setVal(defaults[path]);
             // TODO: would be good to not include nodes that weren't in the defaults parameter
             // HOWEVER, that would also set number of repeats to 0, which may be undesired
             // TODO: would be good to just pass model along instead of converting to string first

--- a/packages/enketo-express/public/js/src/enketo-webform.js
+++ b/packages/enketo-express/public/js/src/enketo-webform.js
@@ -238,6 +238,29 @@ const PROTECTED_META_FIELDS = new Set([
     'audit',
 ]);
 
+function _isAllowedDefault(path, targetNode, rootElement) {
+    // Defaults should not target attributes
+    if (path.includes('@')) return false;
+    // Must resolve to a node strictly inside the primary instance root
+    if (
+        !targetNode ||
+        !rootElement.contains(targetNode) ||
+        targetNode === rootElement
+    )
+        return false;
+    // Defaults should not target groups, only leaf fields
+    if (targetNode.children.length > 0) return false;
+    // Standard ODK metadata fields must not be overridden
+    const metaEl = rootElement.querySelector(':scope > meta');
+    if (
+        metaEl &&
+        metaEl.contains(targetNode) &&
+        PROTECTED_META_FIELDS.has(targetNode.localName)
+    )
+        return false;
+    return true;
+}
+
 export function _prepareInstance(modelStr, defaults) {
     let model;
     let init;
@@ -251,38 +274,15 @@ export function _prepareInstance(modelStr, defaults) {
                     full: false,
                 });
             init = init || model.init();
-            // Defaults should not target attributes
-            if (path.includes('@')) {
-                continue;
-            }
             const targetNode = model.node(path).getElement();
-            // Must resolve to a node strictly inside the primary instance root
-            if (
-                !targetNode ||
-                !model.rootElement.contains(targetNode) ||
-                targetNode === model.rootElement
-            ) {
-                continue;
+            if (_isAllowedDefault(path, targetNode, model.rootElement)) {
+                // if this fails, the FormModel will output a console error and ignore the instruction
+                model.node(path).setVal(defaults[path]);
+                // TODO: would be good to not include nodes that weren't in the defaults parameter
+                // HOWEVER, that would also set number of repeats to 0, which may be undesired
+                // TODO: would be good to just pass model along instead of converting to string first
+                existingInstance = model.getStr();
             }
-            // Defaults should not target groups, only leaf fields
-            if (targetNode.children.length > 0) {
-                continue;
-            }
-            // Standard ODK metadata fields must not be overridden
-            const metaEl = model.rootElement.querySelector(':scope > meta');
-            if (
-                metaEl &&
-                metaEl.contains(targetNode) &&
-                PROTECTED_META_FIELDS.has(targetNode.localName)
-            ) {
-                continue;
-            }
-            // if this fails, the FormModel will output a console error and ignore the instruction
-            model.node(path).setVal(defaults[path]);
-            // TODO: would be good to not include nodes that weren't in the defaults parameter
-            // HOWEVER, that would also set number of repeats to 0, which may be undesired
-            // TODO: would be good to just pass model along instead of converting to string first
-            existingInstance = model.getStr();
         }
     }
 

--- a/packages/enketo-express/test/client/feature/url-defaults.spec.js
+++ b/packages/enketo-express/test/client/feature/url-defaults.spec.js
@@ -15,7 +15,7 @@ const MODEL = `<model>
   </instance>
 </model>`;
 
-describe.only('URL defaults (_prepareInstance)', () => {
+describe('URL defaults (_prepareInstance)', () => {
     const parser = new DOMParser();
 
     it('applies a default value to a matching leaf node', () => {

--- a/packages/enketo-express/test/client/feature/url-defaults.spec.js
+++ b/packages/enketo-express/test/client/feature/url-defaults.spec.js
@@ -78,7 +78,9 @@ describe.only('URL defaults (_prepareInstance)', () => {
         });
         const doc = parser.parseFromString(result, 'text/xml');
         expect(doc.querySelector('name').textContent).to.equal('Alice');
-        expect(doc.querySelector('instanceID').textContent).to.equal('');
+        expect(doc.querySelector('instanceID').textContent).to.not.equal(
+            'fixed-uuid'
+        );
     });
 
     it('allows a default on a field nested inside a group', () => {

--- a/packages/enketo-express/test/client/feature/url-defaults.spec.js
+++ b/packages/enketo-express/test/client/feature/url-defaults.spec.js
@@ -1,0 +1,110 @@
+import { _prepareInstance } from '../../../public/js/src/enketo-webform';
+
+const MODEL = `<model>
+  <instance>
+    <myform id="myform">
+      <name/>
+      <age/>
+      <email/>
+      <respondent>
+        <first_name/>
+        <last_name/>
+      </respondent>
+      <meta><instanceID/></meta>
+    </myform>
+  </instance>
+</model>`;
+
+describe.only('URL defaults (_prepareInstance)', () => {
+    const parser = new DOMParser();
+
+    it('applies a default value to a matching leaf node', () => {
+        const result = _prepareInstance(MODEL, { '/myform/name': 'Alice' });
+        const doc = parser.parseFromString(result, 'text/xml');
+
+        expect(doc.querySelector('name').textContent).to.equal('Alice');
+    });
+
+    it('returns null when defaults is empty', () => {
+        expect(_prepareInstance(MODEL, {})).to.be.null;
+    });
+
+    it('applies multiple defaults independently', () => {
+        const result = _prepareInstance(MODEL, {
+            '/myform/name': 'Bob',
+            '/myform/age': '30',
+        });
+        const doc = parser.parseFromString(result, 'text/xml');
+
+        expect(doc.querySelector('name').textContent).to.equal('Bob');
+        expect(doc.querySelector('age').textContent).to.equal('30');
+    });
+
+    it('rejects a path targeting the primary instance root', () => {
+        const result = _prepareInstance(MODEL, { '/myform': 'injected' });
+        // rejected path produces no instance output
+        expect(result).to.be.null;
+    });
+
+    it('rejects a path targeting an attribute of the primary instance root', () => {
+        const result = _prepareInstance(MODEL, { '/myform/@id': 'injected' });
+        expect(result).to.be.null;
+    });
+
+    it('rejects a path targeting an attribute of a field', () => {
+        const result = _prepareInstance(MODEL, {
+            '/myform/name': 'Alice',
+            '/myform/name/@someattr': 'injected',
+        });
+        const doc = parser.parseFromString(result, 'text/xml');
+        expect(doc.querySelector('name').textContent).to.equal('Alice');
+        expect(doc.querySelector('name').hasAttribute('someattr')).to.be.false;
+    });
+
+    it('allows a field whose name matches a protected meta field name but is outside meta', () => {
+        const result = _prepareInstance(MODEL, {
+            '/myform/email': 'test@example.com',
+        });
+        const doc = parser.parseFromString(result, 'text/xml');
+        expect(doc.querySelector('email').textContent).to.equal(
+            'test@example.com'
+        );
+    });
+
+    it('rejects a path targeting a protected meta field', () => {
+        const result = _prepareInstance(MODEL, {
+            '/myform/name': 'Alice',
+            '/myform/meta/instanceID': 'fixed-uuid',
+        });
+        const doc = parser.parseFromString(result, 'text/xml');
+        expect(doc.querySelector('name').textContent).to.equal('Alice');
+        expect(doc.querySelector('instanceID').textContent).to.equal('');
+    });
+
+    it('allows a default on a field nested inside a group', () => {
+        const result = _prepareInstance(MODEL, {
+            '/myform/respondent/first_name': 'Alice',
+        });
+        const doc = parser.parseFromString(result, 'text/xml');
+        expect(doc.querySelector('first_name').textContent).to.equal('Alice');
+    });
+
+    it('rejects a path targeting a group element', () => {
+        const result = _prepareInstance(MODEL, {
+            '/myform/respondent': 'injected',
+        });
+        expect(result).to.be.null;
+    });
+
+    it('rejects a path outside the primary instance entirely', () => {
+        const result = _prepareInstance(MODEL, {
+            '/myform/name': 'Alice',
+            '/other/field': 'injected',
+        });
+        const doc = parser.parseFromString(result, 'text/xml');
+        // valid path still applied
+        expect(doc.querySelector('name').textContent).to.equal('Alice');
+        // no 'other' element was created
+        expect(doc.querySelector('other')).to.be.null;
+    });
+});


### PR DESCRIPTION
### 📣 Summary

Improves security during parsing of defaults via query params, ensuring that defaults only alter form questions rather than attributes of the form or other unintended targets.


### 👀 Preview steps

1. Create and deploy a form
2. Load form in enketo with valid defaults in query params: `ee.kobo.local/single/<enketo_id>?d[my_question]=ananswer`
3. See that form initializes with intended default value
4. Alter query params to target invalid elements (e.g. `d[/form_id/@id]=someotherid`)
5. Submit form
6. 🔴 [on main] Observe that invalid target was succesfully altered in request  
7. 🟢 [on PR] Verify that invalid target is not altered
