### PR TITLE
fix(audioWidget): audio widget buttons being triggered by enter DEV-2273

### DIFF
--- a/packages/enketo-core/src/widget/audio/audio.js
+++ b/packages/enketo-core/src/widget/audio/audio.js
@@ -170,12 +170,12 @@ class AudioWidget extends Widget {
         const stepFragment = document.createRange().createContextualFragment(
             `<div class="step-action-select">
                 <div class="button-group">
-                    <button class="btn-record btn btn-primary small">
+                    <button type="button" class="btn-record btn btn-primary small">
                     <i class="icon icon-volume-down"></i> ${t(
                         'audioRecording.startRecording'
                     )}
                     </button>
-                    <button class="btn-upload btn btn-default small">
+                    <button type="button" class="btn-upload btn btn-default small">
                     <i class="icon icon-upload"></i> ${t(
                         'audioRecording.uploadAudioFile'
                     )}
@@ -227,13 +227,13 @@ class AudioWidget extends Widget {
                     </div>
                     <canvas class="audio-waveform"></canvas>
                     <div class="recording-controls">
-                        <button class="btn-icon-only btn-pause">
+                        <button type="button" class="btn-icon-only btn-pause">
                             <i class="icon icon-pause"></i>
                         </button>
-                        <button class="btn-icon-only btn-resume hidden">
+                        <button type="button" class="btn-icon-only btn-resume hidden">
                             <i class="icon icon-microphone"></i>
                         </button>
-                        <button class="btn-icon-only btn-stop">
+                        <button type="button" class="btn-icon-only btn-stop">
                             <i class="icon icon-stop"></i>
                         </button>
                     </div>
@@ -329,10 +329,10 @@ class AudioWidget extends Widget {
         const stepFragment = document.createRange().createContextualFragment(
             `<div class="step-preview">
                 <div class="audio-preview">
-                    <button class="btn-icon-only btn-play">
+                    <button type="button" class="btn-icon-only btn-play">
                         <i class="icon icon-play"></i>
                     </button>
-                    <button class="btn-icon-only btn-pause hidden">
+                    <button type="button" class="btn-icon-only btn-pause hidden">
                         <i class="icon icon-pause"></i>
                     </button>
                     <span class="time-progress">00:00 / 1:24</span>
@@ -342,10 +342,10 @@ class AudioWidget extends Widget {
                         </div>
                     </div>
                 </div>
-                <button class="btn-icon-only btn-download">
+                <button type="button" class="btn-icon-only btn-download">
                     <i class="icon icon-download"></i>
                 </button>
-                <button class="btn-icon-only btn-delete">
+                <button type="button" class="btn-icon-only btn-delete">
                     <i class="icon icon-trash"></i>
                 </button>
             </div>`


### PR DESCRIPTION
### 📣 Summary

Pressing `Enter` on a text input field when an audio widget is present won't trigger the audio recording anymore.

### 💭 Notes

Button elements in the audio widget were missing `type="button"`, causing them to default to `type="submit"`. When Enter was pressed inside an `<input>`, the browser fired an implicit form submission and activated the first submit-type button in the DOM — which happened to be the audio widget's **Start Recording** button. 
The fix adds `type="button"` to all buttons of audio widget to avoid the issue.

### 👀 Preview steps

<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

Template:

1. ℹ️ have an account and a project with an audio widget and other widgets containing text inputs
2. open the form on Enketo
3. Give focus to a text input element and press `Enter`
4. 🔴 [on main] notice that audio widget starts recording
5. 🟢 [on PR] notice that nothing happens other than the expected for the given text input (e.g: search result if in a seartch input)
