### PR TITLE
feat(encryption): support editing instances from encrypted forms

### DIFF
--- a/packages/enketo-express/public/js/src/module/controller-webform.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform.js
@@ -134,6 +134,9 @@ function init(formEl, data, loadErrors = []) {
             }
 
             if (form.encryptionKey) {
+                if (data.instanceAttachments) {
+                    fileManager.prefetchInstanceAttachments();
+                }
                 const saveDraftButton = document.querySelector(
                     '.form-footer#save-draft'
                 );

--- a/packages/enketo-express/public/js/src/module/file-manager.js
+++ b/packages/enketo-express/public/js/src/module/file-manager.js
@@ -15,6 +15,9 @@ const URL_RE = /[a-zA-Z0-9+-.]+?:\/\//;
 /** @type {Record<string, string>} */
 let instanceAttachments;
 
+/** @type {Map<string, Blob>} */
+const prefetchedBlobCache = new Map();
+
 /**
  * Initialize the file manager .
  *
@@ -41,6 +44,48 @@ function isWaitingForPermissions() {
  */
 function setInstanceAttachments(attachments) {
     instanceAttachments = attachments;
+    if (!attachments) {
+        prefetchedBlobCache.clear();
+    }
+}
+
+/**
+ * Pre-fetches all instance attachment URLs and caches the resulting Blobs.
+ * Should be called immediately after setInstanceAttachments while the
+ * server-side cache is still fresh.
+ *
+ * @return {Promise<void>}
+ */
+function prefetchInstanceAttachments() {
+    if (!instanceAttachments) {
+        return Promise.resolve();
+    }
+
+    const fetchPromises = Object.entries(instanceAttachments).map(
+        ([filename, url]) =>
+            fetch(url, { credentials: 'include' })
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error(
+                            `Failed to fetch ${filename}: ${response.status}`
+                        );
+                    }
+
+                    return response.blob();
+                })
+                .then((blob) => {
+                    blob.name = filename;
+                    prefetchedBlobCache.set(filename, blob);
+                })
+                .catch((err) => {
+                    console.warn(
+                        `Failed to prefetch attachment "${filename}":`,
+                        err
+                    );
+                })
+    );
+
+    return Promise.all(fetchPromises).then(() => undefined);
 }
 /**
  * Obtains a url that can be used to show a preview of the file when used
@@ -204,9 +249,11 @@ function getCurrentFiles() {
         // get any file names of files that were loaded as DataURI and have remained unchanged (i.e. loaded from Storage)
         fileInputs
             .filter((input) => input.matches('[data-loaded-file-name]'))
-            .forEach((input) =>
-                files.push(input.getAttribute('data-loaded-file-name'))
-            );
+            .forEach((input) => {
+                const filename = input.getAttribute('data-loaded-file-name');
+                const cached = prefetchedBlobCache.get(filename);
+                files.push(cached || filename);
+            });
 
         return files;
     });
@@ -269,6 +316,7 @@ export default {
     isWaitingForPermissions,
     init,
     setInstanceAttachments,
+    prefetchInstanceAttachments,
     getFileUrl,
     getObjectUrl,
     getCurrentFiles,

--- a/packages/enketo-express/test/client/file-manager.spec.js
+++ b/packages/enketo-express/test/client/file-manager.spec.js
@@ -82,6 +82,102 @@ describe('File manager', () => {
             });
         });
 
+        describe('prefetching instance attachments', () => {
+            afterEach(() => {
+                fileManager.setInstanceAttachments(null);
+            });
+
+            it('prefetchInstanceAttachments fetches and caches blobs', async () => {
+                const content = 'test image content';
+                const dataURI = `data:image/jpeg;base64,${btoa(content)}`;
+
+                fileManager.setInstanceAttachments({
+                    'photo.jpg': dataURI,
+                });
+
+                await fileManager.prefetchInstanceAttachments();
+
+                // Verify by creating a DOM input with data-loaded-file-name
+                // and checking getCurrentFiles returns a Blob
+                const formEl = document.createElement('form');
+                formEl.className = 'or';
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.setAttribute('data-loaded-file-name', 'photo.jpg');
+                formEl.appendChild(input);
+                document.body.appendChild(formEl);
+
+                try {
+                    const files = await fileManager.getCurrentFiles();
+                    expect(files.length).to.equal(1);
+                    expect(files[0]).to.be.an.instanceof(Blob);
+                    expect(files[0].name).to.equal('photo.jpg');
+                } finally {
+                    document.body.removeChild(formEl);
+                }
+            });
+
+            it('getCurrentFiles returns string filename when not prefetched', async () => {
+                fileManager.setInstanceAttachments({
+                    'photo.jpg': 'https://example.com/photo.jpg',
+                });
+
+                // Do NOT call prefetchInstanceAttachments
+
+                const formEl = document.createElement('form');
+                formEl.className = 'or';
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.setAttribute('data-loaded-file-name', 'photo.jpg');
+                formEl.appendChild(input);
+                document.body.appendChild(formEl);
+
+                try {
+                    const files = await fileManager.getCurrentFiles();
+                    expect(files.length).to.equal(1);
+                    expect(files[0]).to.equal('photo.jpg');
+                } finally {
+                    document.body.removeChild(formEl);
+                }
+            });
+
+            it('clearing instance attachments clears prefetch cache', async () => {
+                const content = 'test content';
+                const dataURI = `data:image/jpeg;base64,${btoa(content)}`;
+
+                fileManager.setInstanceAttachments({
+                    'photo.jpg': dataURI,
+                });
+
+                await fileManager.prefetchInstanceAttachments();
+
+                // Clear attachments (and cache)
+                fileManager.setInstanceAttachments(null);
+
+                // Re-set attachments but don't prefetch
+                fileManager.setInstanceAttachments({
+                    'photo.jpg': 'https://example.com/photo.jpg',
+                });
+
+                const formEl = document.createElement('form');
+                formEl.className = 'or';
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.setAttribute('data-loaded-file-name', 'photo.jpg');
+                formEl.appendChild(input);
+                document.body.appendChild(formEl);
+
+                try {
+                    const files = await fileManager.getCurrentFiles();
+                    expect(files.length).to.equal(1);
+                    // Should be string since cache was cleared
+                    expect(files[0]).to.equal('photo.jpg');
+                } finally {
+                    document.body.removeChild(formEl);
+                }
+            });
+        });
+
         describe('cached resources', () => {
             const enketoId = 'survey a';
             const recordId = 'record 1';


### PR DESCRIPTION
### 📣 Summary

Adds the ability to edit and save submissions from encrypted forms while keeping existing photos and attachments

### 📖 Description

When a submission is loaded for editing, only a preview of the attachments is rendered; the blobs aren't refetched. This works fine for unencrypted forms, but for encrypted forms, every media file has to be re-encrypted locally before saving since the encryption process needs the actual blob, not just the filename.

We hit this while building our managed form encryption and decryption feature. A user editing a decrypted submission on Enketo would get a save failure with the error `TypeError: Require Blob` unless they manually reattached every media file.

The change is additive and gated: non-encrypted edit flows are unaffected (falls back to the existing filename-string behavior).

closes #1583 
