### PR TITLE
DOMPurify: clear persistent config before sanitisation

### DIFF
--- a/packages/enketo-core/src/js/sanitization-utils.js
+++ b/packages/enketo-core/src/js/sanitization-utils.js
@@ -464,6 +464,7 @@ function sanitizeSvg(svgElement) {
     DOMPurify.addHook('afterSanitizeAttributes', afterSanitizeAttributesHook);
 
     try {
+        DOMPurify.clearConfig();
         DOMPurify.sanitize(sanitizedSvg, DOMPURIFY_SVG_CONFIG);
     } finally {
         DOMPurify.removeHook('uponSanitizeElement', uponSanitizeElementHook);

--- a/packages/enketo-core/test/spec/sanitization-utils.spec.js
+++ b/packages/enketo-core/test/spec/sanitization-utils.spec.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 import { sanitizeSvg } from '../../src/js/sanitization-utils';
 
 describe('SVG Sanitization', () => {
@@ -368,5 +370,25 @@ describe('SVG Sanitization', () => {
 
     it('should return null for undefined input', () => {
         expect(sanitizeSvg(undefined)).to.be.null;
+    });
+
+    it('should not be affected by 3rd-party calls to DOMPurify.setConfig()', () => {
+        const maliciousSvg = parser
+            .parseFromString(
+                `
+            <svg xmlns="http://www.w3.org/2000/svg">
+                <script>alert('XSS')</script>
+                <path id="safe" d="M 10 10 L 20 20"/>
+            </svg>
+        `,
+                'text/xml'
+            )
+            .querySelector('svg');
+
+        DOMPurify.setConfig({ ALLOWED_TAGS:[], ALLOWED_ATTR:[] });
+        const sanitized = sanitizeSvg(maliciousSvg);
+
+        expect(sanitized.querySelector('script')).to.be.null;
+        expect(sanitized.querySelector('path')).to.not.be.null;
     });
 });

--- a/packages/enketo-core/test/spec/sanitization-utils.spec.js
+++ b/packages/enketo-core/test/spec/sanitization-utils.spec.js
@@ -385,7 +385,7 @@ describe('SVG Sanitization', () => {
             )
             .querySelector('svg');
 
-        DOMPurify.setConfig({ ALLOWED_TAGS:[], ALLOWED_ATTR:[] });
+        DOMPurify.setConfig({ ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
         const sanitized = sanitizeSvg(maliciousSvg);
 
         expect(sanitized.querySelector('script')).to.be.null;


### PR DESCRIPTION
By design, DOMPurify falls back to a global "persistent" configuration if set with `DOMPurify.setConfig(...)`.  This means that if `enketo-core` is included as a library in another package (e.g. `enketo/enketo-express`, `medic/cht-core` etc.), and the parent package calls `DOMPurify.setConfig()` anywhere, it will affect later behaviour of `DOMPurify.sanitize()` calls in `enketo-core`.

See:

* https://github.com/cure53/DOMPurify#persistent-configuration
* https://github.com/cure53/DOMPurify/issues/1134

### 🗒️ Checklist

- [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`: no, i don't have access to private issue tracker
- [x] assign yourself
- [x] fill in the template below and delete template comments
- [x] update all related docs (README, inline, etc.), if any
- [ ] I have verified this PR works by manually testing (see CONTRIBUTING.md):
    - [ ] Online form submission
    - [ ] Offline form submission
    - [ ] Saving offline drafts
    - [ ] Loading offline drafts
    - [ ] Editing submissions
    - [ ] Form preview
    - [x] None of the above
- [x] review thyself: read the diff and repro the preview as written
- [x] undraft PR & confirm that CI passes
- [ ] request reviewers & improve according to review
- [ ] delete this section before merging

### 📣 Summary

Prevent DOMPurify config pollution.

### 📖 Description


<!-- Full description, worded for non-technical seasoned Enketo end-users. -->
<!-- Examples:
- How does this change affect users?
- What are the intentional changes to behavior?
-->

### 👷 Description for integrators



### 💭 Notes

By design, DOMPurify falls back to a global "persistent" configuration if set with `DOMPurify.setConfig(...)`.  This means that if `enketo-core` is included as a library in another package (e.g. `enketo/enketo-express`, `medic/cht-core` etc.), and the parent package calls `DOMPurify.setConfig()` anywhere, it will affect later behaviour of `DOMPurify.sanitize()` calls in `enketo-core`.

See:

* https://github.com/cure53/DOMPurify#persistent-configuration
* https://github.com/cure53/DOMPurify/issues/1134

### 👀 Preview steps

<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

Template:

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere BUT it should be here
5. 🟢 [on PR] notice that this is here
