### PR TITLE
DOMPurify: clear hooks before sanitisation

### DIFF
--- a/packages/enketo-core/src/js/sanitization-utils.js
+++ b/packages/enketo-core/src/js/sanitization-utils.js
@@ -460,11 +460,13 @@ function sanitizeSvg(svgElement) {
         }
     };
 
+    DOMPurify.clearConfig();
+    DOMPurify.removeAllHooks();
+
     DOMPurify.addHook('uponSanitizeElement', uponSanitizeElementHook);
     DOMPurify.addHook('afterSanitizeAttributes', afterSanitizeAttributesHook);
 
     try {
-        DOMPurify.clearConfig();
         DOMPurify.sanitize(sanitizedSvg, DOMPURIFY_SVG_CONFIG);
     } finally {
         DOMPurify.removeHook('uponSanitizeElement', uponSanitizeElementHook);

--- a/packages/enketo-core/test/spec/sanitization-utils.spec.js
+++ b/packages/enketo-core/test/spec/sanitization-utils.spec.js
@@ -391,4 +391,30 @@ describe('SVG Sanitization', () => {
         expect(sanitized.querySelector('script')).to.be.null;
         expect(sanitized.querySelector('path')).to.not.be.null;
     });
+
+    it('should not be affected by 3rd-party calls to DOMPurify.addHook()', () => {
+        const maliciousSvg = parser
+            .parseFromString(
+                `
+            <svg xmlns="http://www.w3.org/2000/svg" onload="alert('XSS')">
+                <path id="test" onclick="alert('click')" d="M 10 10 L 20 20"/>
+            </svg>
+        `,
+                'text/xml'
+            )
+            .querySelector('svg');
+
+        DOMPurify.addHook('uponSanitizeAttribute', (_, hookEvent) => {
+            hookEvent.forceKeepAttr = true;
+        });
+
+        const sanitized = sanitizeSvg(maliciousSvg);
+
+        expect(sanitized.hasAttribute('onload')).to.be.false;
+        expect(sanitized.querySelector('path').hasAttribute('onclick')).to.be
+            .false;
+        expect(sanitized.querySelector('path').getAttribute('id')).to.equal(
+            'test'
+        );
+    });
 });


### PR DESCRIPTION
DOMPurify acts as a singleton, so "hooks" added for any use will persist, perhaps beyond the expectations of developers.

This means that if `enketo-core` is included as a library in another package (e.g.  `enketo/enketo-express`, `medic/cht-core` etc.), and the parent package calls `DOMPurify.addHook()` anywhere, it will affect later behaviour of `DOMPurify.sanitize()` calls in `enketo-core`.

Similar to https://github.com/enketo/enketo/pull/1541, this is a surprising feature of DOMPurify's API.

Ref:

* https://github.com/cure53/DOMPurify/issues/914
* https://github.com/cure53/DOMPurify/issues/1132
* https://github.com/cure53/DOMPurify/issues/1133