### PR TITLE
fix(draw): escape user-supplied attribute values DEV-2339

### DIFF
--- a/packages/enketo-core/src/widget/draw/draw-widget.js
+++ b/packages/enketo-core/src/widget/draw/draw-widget.js
@@ -9,7 +9,11 @@ import dialog from 'enketo/dialog';
 import support from '../../js/support';
 import events from '../../js/event';
 import Widget from '../../js/widget';
-import { dataUriToBlobSync, getFilename, encodeHtmlEntities } from '../../js/utils';
+import {
+    dataUriToBlobSync,
+    getFilename,
+    encodeHtmlEntities,
+} from '../../js/utils';
 import downloadUtils from '../../js/download-utils';
 
 /**

--- a/packages/enketo-core/src/widget/draw/draw-widget.js
+++ b/packages/enketo-core/src/widget/draw/draw-widget.js
@@ -9,7 +9,7 @@ import dialog from 'enketo/dialog';
 import support from '../../js/support';
 import events from '../../js/event';
 import Widget from '../../js/widget';
-import { dataUriToBlobSync, getFilename } from '../../js/utils';
+import { dataUriToBlobSync, getFilename, encodeHtmlEntities } from '../../js/utils';
 import downloadUtils from '../../js/download-utils';
 
 /**
@@ -253,11 +253,11 @@ class DrawWidget extends Widget {
         const load = this.props.load
             ? `<input type="file" class="ignore draw-widget__load"${
                   this.props.capture !== null
-                      ? ` capture="${this.props.capture}"`
+                      ? ` capture="${encodeHtmlEntities(this.props.capture)}"`
                       : ''
-              } accept="${
+              } accept="${encodeHtmlEntities(
                   this.props.accept
-              }"/><div class="widget file-picker"><input class="ignore fake-file-input"/><div class="file-feedback"></div></div>`
+              )}"/><div class="widget file-picker"><input class="ignore fake-file-input"/><div class="file-feedback"></div></div>`
             : '';
         const fullscreenBtns = this.props.touch
             ? '<button type="button" class="show-canvas-btn btn btn-default">Draw/Sign</button>' +

--- a/packages/enketo-core/test/spec/widget.draw.spec.js
+++ b/packages/enketo-core/test/spec/widget.draw.spec.js
@@ -25,13 +25,47 @@ const FORM3 = `<form class="or">
 });
 
 describe('draw widget', () => {
-    it('does not instantiate for non image accept attributes', () => {
-        const form = FORM1.replace(
-            'accept="image/*"',
-            'accept="something/else"'
-        );
-        const fragment = document.createRange().createContextualFragment(form);
-        const control = fragment.querySelector(DrawWidget.selector);
-        expect(control).to.equal(null);
+    describe('widget selection', () => {
+        it('does not instantiate for non image accept attributes', () => {
+            const form = FORM1.replace(
+                'accept="image/*"',
+                'accept="something/else"'
+            );
+            const fragment = document
+                .createRange()
+                .createContextualFragment(form);
+            const control = fragment.querySelector(DrawWidget.selector);
+            expect(control).to.equal(null);
+        });
+    });
+
+    describe('markup', () => {
+        it('preserves valid accept attribute value on file input', () => {
+            const fragment = document
+                .createRange()
+                .createContextualFragment(FORM3);
+            const control = fragment.querySelector('[name="/data/a"]');
+            const widget = new DrawWidget(control, {});
+            const fileInput = widget.question.querySelector(
+                'input[type="file"].draw-widget__load'
+            );
+            expect(fileInput.getAttribute('accept')).to.equal('image/*');
+        });
+
+        it('escapes malicious accept attribute values', () => {
+            const form = FORM3.replace(
+                'accept="image/*"',
+                'accept="image/*&quot;><img src=x onerror=alert(1)>"'
+            );
+            const fragment = document
+                .createRange()
+                .createContextualFragment(form);
+            const control = fragment.querySelector('[name="/data/a"]');
+            const widget = new DrawWidget(control, {});
+            expect(widget.question.querySelector('img[onerror]')).to.equal(
+                null
+            );
+            expect(widget.question.querySelector('[onerror]')).to.equal(null);
+        });
     });
 });


### PR DESCRIPTION
### 📣 Summary

Fix XSS vulnerability in draw/annotate widget by escaping accept and capture attributes before HTML interpolation.

### 👀 Preview steps

Template:

1. Open a form with an annotate widget where mediatype is set to `image/*"><img src=x onerror=alert(document.domain)>`
2. On main, the js will be executed and the alert will fire
3. On this branch, the js will not be executed and the alert will not fire