### PR TITLE
fix(geopicker): input label element covering map on small screens DEV-2348

### DIFF
--- a/packages/enketo-core/src/widget/geo/geopicker.scss
+++ b/packages/enketo-core/src/widget/geo/geopicker.scss
@@ -590,11 +590,10 @@ $input-button-border: 2px solid #aaaaaa;
     .search-bar {
         float: left;
         border-left: none;
-        border-right: solid 1px $groupline; //padding-left: 0;
+        border-right: solid 1px $groupline;
 
-        //padding-right: $separator-width;
         @media screen and (max-width: $geo-main-breakpoint) {
-            //padding-right: 0;
+            float: none;
             border-right: none;
         }
 


### PR DESCRIPTION
### 📣 Summary

Fixed a bug that prevented interaction with the geopicker map when displaying RTL text on small screens.

### 👀 Preview steps

1. Create a project with this form:
[rtl-map.xlsx](https://github.com/user-attachments/files/29595575/rtl-map.xlsx)
2. Open the form in enketo on a small screen
3. On main, notice that the top coordinate input (below the map) label element covers the entire map, so you can't click on the map
4. On PR branch, verify that this is no longer the case.
