### PR TITLE
fix(audioWidget): detect invalid uploaded audio file DEV-2383

### DIFF
--- a/packages/enketo-core/src/widget/audio/audio.js
+++ b/packages/enketo-core/src/widget/audio/audio.js
@@ -52,6 +52,17 @@ class AudioWidget extends Widget {
             // Handle file input change event for uploading audio files
             const file = event.target.files[0];
             if (file) {
+                const isValid = await this.isValidAudioFile(file);
+                if (!isValid) {
+                    this.element.type = 'text';
+                    this.showActionSelectStep();
+                    dialog.alert(
+                        t('audioRecording.error.invalidAudioFile.msg'),
+                        t('audioRecording.error.invalidAudioFile.heading'),
+                        'normal'
+                    );
+                    return;
+                }
                 await this.updateValue(file); // Update the widget with the uploaded file
                 this.fileName = this.postFixFilename(file.name); // Update the filename with a unique timestamp postfix
                 // Restore type to 'text' so getCurrentFiles() uses the data-cache blob
@@ -335,7 +346,7 @@ class AudioWidget extends Widget {
                     <button type="button" class="btn-icon-only btn-pause hidden">
                         <i class="icon icon-pause"></i>
                     </button>
-                    <span class="time-progress">00:00 / 1:24</span>
+                    <span class="time-progress">00:00 / 0:00</span>
                     <div class="seek-bar">
                         <div class="play-progress">
                             <div class="progress-bar"></div>
@@ -487,6 +498,39 @@ class AudioWidget extends Widget {
         return `${baseName}-${timestamp.slice(0, 8)}_${timestamp.slice(
             8
         )}.${extension}`;
+    }
+
+    /**
+     * Checks whether the given file can be decoded as audio by the browser.
+     * Creates a temporary Audio element and attempts to load the file,
+     * resolving to true on success or false on error.
+     *
+     * @param {File} file - The file to verify.
+     * @returns {Promise<boolean>} - Resolves to true if the file is playable audio, false otherwise.
+     */
+    isValidAudioFile(file) {
+        return new Promise((resolve) => {
+            const url = URL.createObjectURL(file);
+            const audio = new Audio();
+            const cleanup = () => URL.revokeObjectURL(url);
+            audio.addEventListener(
+                'canplay',
+                () => {
+                    cleanup();
+                    resolve(true);
+                },
+                { once: true }
+            );
+            audio.addEventListener(
+                'error',
+                () => {
+                    cleanup();
+                    resolve(false);
+                },
+                { once: true }
+            );
+            audio.src = url;
+        });
     }
 
     /**

--- a/packages/enketo-core/test/spec/widget.audio.spec.js
+++ b/packages/enketo-core/test/spec/widget.audio.spec.js
@@ -1,4 +1,5 @@
 import AudioWidget from '../../src/widget/audio/audio';
+import dialog from '../../src/js/fake-dialog';
 import {
     testStaticProperties,
     testRequiredMethods,
@@ -213,6 +214,7 @@ describe('AudioWidget', () => {
 
             control.type = 'file';
             const postFixSpy = sandbox.spy(widget, 'postFixFilename');
+            sandbox.stub(widget, 'isValidAudioFile').resolves(true);
 
             Object.defineProperty(control, 'files', {
                 get: () => ({ 0: file, length: 1 }),
@@ -242,6 +244,7 @@ describe('AudioWidget', () => {
             });
 
             control.type = 'file';
+            sandbox.stub(widget, 'isValidAudioFile').resolves(true);
 
             Object.defineProperty(control, 'files', {
                 get: () => ({ 0: file, length: 1 }),
@@ -260,13 +263,14 @@ describe('AudioWidget', () => {
         });
 
         it('resets element type to text after upload', (done) => {
-            const { control } = createWidget();
+            const { widget, control } = createWidget();
 
             const file = new File(['audio data'], 'test.webm', {
                 type: 'audio/webm',
             });
 
             control.type = 'file';
+            sandbox.stub(widget, 'isValidAudioFile').resolves(true);
 
             Object.defineProperty(control, 'files', {
                 get: () => ({ 0: file, length: 1 }),
@@ -278,6 +282,58 @@ describe('AudioWidget', () => {
             // FileReader is macrotask-based; setTimeout ensures all async work completes
             setTimeout(() => {
                 expect(control.type).to.equal('text');
+                done();
+            }, 0);
+        });
+
+        it('shows an error and stays on action-select step when file is not valid audio', (done) => {
+            const { widget, control } = createWidget();
+
+            const file = new File(['this is not audio content'], 'test.mp3', {
+                type: 'audio/mpeg',
+            });
+
+            control.type = 'file';
+            sandbox.stub(widget, 'isValidAudioFile').resolves(false);
+            const alertStub = sandbox.stub(dialog, 'alert').resolves();
+
+            Object.defineProperty(control, 'files', {
+                get: () => ({ 0: file, length: 1 }),
+                configurable: true,
+            });
+
+            control.dispatchEvent(new Event('change', { bubbles: true }));
+
+            setTimeout(() => {
+                const actionSelect = widget.question.querySelector(
+                    '.step-action-select'
+                );
+                expect(actionSelect).not.to.equal(null);
+                expect(alertStub.calledOnce).to.equal(true);
+                done();
+            }, 0);
+        });
+
+        it('does not proceed to playback step when file is not valid audio', (done) => {
+            const { widget, control } = createWidget();
+
+            const file = new File(['this is not audio content'], 'fake.mp3', {
+                type: 'audio/mpeg',
+            });
+
+            control.type = 'file';
+            sandbox.stub(widget, 'isValidAudioFile').resolves(false);
+            const showPlaybackSpy = sandbox.spy(widget, 'showPlaybackStep');
+
+            Object.defineProperty(control, 'files', {
+                get: () => ({ 0: file, length: 1 }),
+                configurable: true,
+            });
+
+            control.dispatchEvent(new Event('change', { bubbles: true }));
+
+            setTimeout(() => {
+                expect(showPlaybackSpy.called).to.equal(false);
                 done();
             }, 0);
         });

--- a/packages/enketo-express/locales/src/en/translation.json
+++ b/packages/enketo-express/locales/src/en/translation.json
@@ -139,7 +139,11 @@
             "notSupported": "Audio recording is not supported in this browser.",
             "unknownError": "Failed to access microphone. Check your browser settings and permissions.",
             "recordingError": "An error occurred while trying to record audio.",
-            "recordingInProgress": "The current audio recording needs to be stopped before continuing."
+            "recordingInProgress": "The current audio recording needs to be stopped before continuing.",
+            "invalidAudioFile": {
+                "msg": "The selected file is not a valid audio file and cannot be played.",
+                "heading": "Invalid Audio File"
+            }
         },
         "startRecording": "Start Recording",
         "uploadAudioFile": "Upload audio File",

--- a/packages/enketo-express/locales/src/es/translation.json
+++ b/packages/enketo-express/locales/src/es/translation.json
@@ -138,7 +138,11 @@
             "noMicrophone": "No se encontró ningún micrófono en este dispositivo.",
             "notSupported": "La grabación de audio no es compatible con este navegador.",
             "unknownError": "Error al acceder al micrófono: __errorMessage__",
-            "recordingError": "Ocurrió un error al intentar grabar audio."
+            "recordingError": "Ocurrió un error al intentar grabar audio.",
+            "invalidAudioFile": {
+                "msg": "El archivo seleccionado no es un archivo de audio válido y no se puede reproducir.",
+                "heading": "Archivo de audio no válido"
+            }
         },
         "startRecording": "Iniciar grabación",
         "uploadAudioFile": "Subir archivo",

--- a/packages/enketo-express/locales/src/fr/translation.json
+++ b/packages/enketo-express/locales/src/fr/translation.json
@@ -138,7 +138,11 @@
             "noMicrophone": "Aucun micro trouvé sur cet appareil.",
             "notSupported": "L'enregistrement audio n'est pas pris en charge par ce navigateur.",
             "unknownError": "Erreur lors de l'accès au micro : __errorMessage__",
-            "recordingError": "Une erreur s'est produite lors de la tentative d'enregistrement audio."
+            "recordingError": "Une erreur s'est produite lors de la tentative d'enregistrement audio.",
+            "invalidAudioFile": {
+                "msg": "Le fichier sélectionné n'est pas un fichier audio valide et ne peut pas être lu.",
+                "heading": "Fichier audio invalide"
+            }
         },
         "startRecording": "Démarrer l'enregistrement",
         "uploadAudioFile": "Téléverser le fichier",

--- a/packages/enketo-express/locales/src/pt/translation.json
+++ b/packages/enketo-express/locales/src/pt/translation.json
@@ -128,7 +128,11 @@
             "noMicrophone": "Nenhum microfone encontrado neste dispositivo.",
             "notSupported": "Gravação de áudio não é suportada neste navegador.",
             "unknownError": "Falha ao acessar o microfone. Verifique as configurações e permissões do seu navegador.",
-            "recordingError": "Ocorreu um erro ao tentar gravar áudio."
+            "recordingError": "Ocorreu um erro ao tentar gravar áudio.",
+            "invalidAudioFile": {
+                "msg": "O arquivo selecionado não é um arquivo de áudio válido e não pode ser reproduzido.",
+                "heading": "Arquivo de áudio inválido"
+            }
         },
         "startRecording": "Iniciar gravação",
         "uploadAudioFile": "Enviar arquivo",


### PR DESCRIPTION
### 📣 Summary

Now files selectd for uploading are checked to be valid audio files


### 💭 Notes

Audio widget was accepting any file renamed to an audio file extension as uploaded. That was causing the file to not be parsed properly and player to not work, but without a check the state of the widget changed and a placeholder information was being displayed.
That was opening possibility to send invalid audio files to the server.

Now a validation function and tests were included to make sure the selected file is playable before accepting it.

### 👀 Preview steps

1. ℹ️ have an account and a project with an audio question
2. rename a not audio file to .mp3
3. Click "upload audio file" and pick the renamed file
4. 🔴 [on main] file is accepted, but cannot be played back. Information displays the 1:24 placeholder
5. 🟢 [on PR] a message is displayed to the user and the file is not accepted
