### PR TITLE
core: downgrade leaflet.gridlayer.googlemutant to v0.15.0

### DIFF
--- a/packages/enketo-core/package.json
+++ b/packages/enketo-core/package.json
@@ -61,7 +61,7 @@
         "jquery-touchswipe": "^1.6.19",
         "leaflet": "^1.9.4",
         "leaflet-draw": "github:enketo/Leaflet.draw#ff73078",
-        "leaflet.gridlayer.googlemutant": "^0.16.0",
+        "leaflet.gridlayer.googlemutant": "^0.15.0",
         "mergexml": "1.2.4",
         "node-forge": "^1.4.0",
         "openrosa-xpath-evaluator": "3.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6569,10 +6569,10 @@ language-tags@^1.0.9:
   version "1.0.4"
   resolved "https://codeload.github.com/enketo/Leaflet.draw/tar.gz/ff730785db7fcccbf2485ffcf4dffe1238a7c617"
 
-leaflet.gridlayer.googlemutant@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/leaflet.gridlayer.googlemutant/-/leaflet.gridlayer.googlemutant-0.16.0.tgz#93c9b84b02763b2fa6f93b925363d8dba04412e3"
-  integrity sha512-wN8DxR5zplhZA6a5998AOluCL97H5lkr1yCLOT7siaQyc+hT6E8kcGqjAuSsEUSoaf/U3H25x8Avkp9OpgJpng==
+leaflet.gridlayer.googlemutant@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/leaflet.gridlayer.googlemutant/-/leaflet.gridlayer.googlemutant-0.15.0.tgz#7a32d949578695b8aa8fa5fd11b40bd7a6ce6c23"
+  integrity sha512-kA5jCOBhCPigyue6YpZMhXMVYA1hM2pDIaJ6u0wSSiSZ2TQ4kZfKuhwkIexcadJfs0BP4FyhZIDZC7hmTlvjOA==
 
 leaflet@^1.9.4:
   version "1.9.4"


### PR DESCRIPTION
Closes https://github.com/enketo/enketo/issues/1574

`leaflet.gridlayer.googlemutant` v0.16.0 doesn't work with the current version of `leaflet` (v1.9.4) - when viewing a map with Google Maps enabled:

1. map tiles fail to load
2. error is logged: `L.GridLayer.GoogleMutant is not a constructor`

See:

* https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant/-/work_items/147
* https://github.com/getodk/central/issues/2071

### 🗒️ Checklist

- [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
- [x] assign yourself
- [x] fill in the template below and delete template comments
- [x] update all related docs (README, inline, etc.), if any
- [ ] I have verified this PR works by manually testing (see CONTRIBUTING.md):
    - [ ] Online form submission
    - [ ] Offline form submission
    - [ ] Saving offline drafts
    - [ ] Loading offline drafts
    - [ ] Editing submissions
    - [ ] Form preview
    - [x] None of the above
- [x] review thyself: read the diff and repro the preview as written
- [x] undraft PR & confirm that CI passes
- [ ] request reviewers & improve according to review
- [ ] delete this section before merging

### 📣 Summary

Fix map rendering when using Google Maps tiles.

Template:

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere BUT it should be here
5. 🟢 [on PR] notice that this is here
