### PR TITLE
feat(filepicker): add support for HEIC/HEIF file extensions DEV-2396

### DIFF
--- a/packages/enketo-core/src/widget/draw/draw-widget.js
+++ b/packages/enketo-core/src/widget/draw/draw-widget.js
@@ -615,7 +615,11 @@ class DrawWidget extends Widget {
                       'darkgray',
                   ];
         props.touch = support.touch;
-        props.accept = this.element.getAttribute('accept');
+        const accept = this.element.getAttribute('accept');
+        // Ensure HEIC/HEIF files appear under "Image Files" in the OS file picker,
+        // since `image/*` alone excludes them on most non-Apple browsers/OS.
+        props.accept =
+            accept === 'image/*' ? 'image/*,image/heic,image/heif' : accept;
         props.capture = this.element.getAttribute('capture');
 
         return props;

--- a/packages/enketo-core/src/widget/draw/draw-widget.js
+++ b/packages/enketo-core/src/widget/draw/draw-widget.js
@@ -618,8 +618,12 @@ class DrawWidget extends Widget {
         const accept = this.element.getAttribute('accept');
         // Ensure HEIC/HEIF files appear under "Image Files" in the OS file picker,
         // since `image/*` alone excludes them on most non-Apple browsers/OS.
+        // File extensions (.heic/.heif) are needed alongside MIME types because
+        // image/heic is not registered in most Linux MIME databases.
         props.accept =
-            accept === 'image/*' ? 'image/*,image/heic,image/heif' : accept;
+            accept === 'image/*'
+                ? 'image/*,image/heic,image/heif,.heic,.heif'
+                : accept;
         props.capture = this.element.getAttribute('capture');
 
         return props;

--- a/packages/enketo-core/src/widget/file/filepicker.js
+++ b/packages/enketo-core/src/widget/file/filepicker.js
@@ -34,10 +34,12 @@ class Filepicker extends Widget {
 
         // Ensure HEIC/HEIF files appear under "Image Files" in the OS file picker,
         // since `image/*` alone excludes them on most non-Apple browsers/OS.
+        // File extensions (.heic/.heif) are needed alongside MIME types because
+        // image/heic is not registered in most Linux MIME databases.
         if (this.element.getAttribute('accept') === 'image/*') {
             this.element.setAttribute(
                 'accept',
-                'image/*,image/heic,image/heif'
+                'image/*,image/heic,image/heif,.heic,.heif'
             );
         }
 

--- a/packages/enketo-core/src/widget/file/filepicker.js
+++ b/packages/enketo-core/src/widget/file/filepicker.js
@@ -32,6 +32,15 @@ class Filepicker extends Widget {
         );
         const that = this;
 
+        // Ensure HEIC/HEIF files appear under "Image Files" in the OS file picker,
+        // since `image/*` alone excludes them on most non-Apple browsers/OS.
+        if (this.element.getAttribute('accept') === 'image/*') {
+            this.element.setAttribute(
+                'accept',
+                'image/*,image/heic,image/heif'
+            );
+        }
+
         this.element.classList.add('hide');
         this.question.classList.add('with-media', 'clearfix');
 

--- a/packages/enketo-core/test/spec/widget.draw.spec.js
+++ b/packages/enketo-core/test/spec/widget.draw.spec.js
@@ -49,7 +49,9 @@ describe('draw widget', () => {
             const fileInput = widget.question.querySelector(
                 'input[type="file"].draw-widget__load'
             );
-            expect(fileInput.getAttribute('accept')).to.equal('image/*');
+            expect(fileInput.getAttribute('accept')).to.equal(
+                'image/*,image/heic,image/heif,.heic,.heif'
+            );
         });
 
         it('escapes malicious accept attribute values', () => {


### PR DESCRIPTION
### 📣 Summary

This PR adds support for listing .heic and .heif files in the file picker dialog for images.

### 💭 Notes

These file formats are becoming very popular due to iPhones, and KPI was changes to support them already. It's already possible for the user to pick those files, but they need to change the "File type" in the file browser dialog.
Now the .heic and .heif files are listed when "Image Files" is selected.

Before:
<img width="973" height="493" alt="image" src="https://github.com/user-attachments/assets/0b01a32d-6635-49df-8c97-3bbfe1546647" />

After:
<img width="973" height="493" alt="image" src="https://github.com/user-attachments/assets/86faf677-3a9a-4eb9-bfab-32b21cc5da35" />


### 👀 Preview steps
1. Have .heic and .heif files available
1. ℹ️ open a form with a image picker
2. click to select image
3. 🔴 [on main] notice that .heic and .heif files are not listed
4. 🟢 [on PR] notice that .heic and .heif files are listed by default
