### PR TITLE
feat(store): implement IndexedDB schema and reconnection logic DEV-2436

### DIFF
--- a/packages/enketo-express/public/js/src/module/records-queue.js
+++ b/packages/enketo-express/public/js/src/module/records-queue.js
@@ -106,7 +106,9 @@ function save(action, record) {
             return result;
         })
         .then(({ enketoId }) => formCache.get({ enketoId }))
-        .then((survey) => setLastSavedRecord(survey, record))
+        .then((survey) =>
+            survey ? setLastSavedRecord(survey, record) : undefined
+        )
         .then(_updateRecordList)
         .then(() => result);
 }

--- a/packages/enketo-express/public/js/src/module/store.js
+++ b/packages/enketo-express/public/js/src/module/store.js
@@ -35,6 +35,180 @@ const version = 4;
 
 const REMOVE_RECORD_NAME_UNIQUENESS_VERSION = 4;
 
+// the enketo db.js schema, shared between the initial connection and any
+// reconnection attempts (see `_openDatabase`)
+const schema = {
+    // the surveys
+    surveys: {
+        key: {
+            keyPath: 'enketoId',
+            autoIncrement: false,
+        },
+        indexes: {
+            enketoId: {
+                unique: true,
+            },
+        },
+    },
+    // the resources that belong to a survey
+    resources: {
+        key: {
+            autoIncrement: false,
+        },
+        indexes: {
+            key: {
+                unique: true,
+            },
+        },
+    },
+    // Records in separate table because it makes more sense for getting, updating and removing records
+    // if they are not stored in one (giant) array or object value.
+    // Need to watch out for bad iOS bug: http://www.raymondcamden.com/2014/9/25/IndexedDB-on-iOS-8--Broken-Bad
+    // but with the current keys there is no risk of using the same key in multiple tables.
+    // InstanceId is the key because instanceName may change when editing a draft.
+    records: {
+        key: {
+            keyPath: 'instanceId',
+        },
+        indexes: {
+            // https://github.com/enketo/enketo-express/issues/416
+            recordName: {
+                keyPath: ['enketoId', 'name'],
+                unique: true,
+            },
+            // the actual key
+            instanceId: {
+                unique: true,
+            },
+            // to get all records belonging to a form
+            enketoId: {
+                unique: false,
+            },
+        },
+    },
+    lastSavedRecords: {
+        /**
+         * @see Note on `records` about unique keys across IndexedDB object stores
+         */
+        key: {
+            keyPath: '_enketoId',
+            autoIncrement: false,
+        },
+    },
+    // the files that belong to a record
+    files: {
+        key: {
+            autoIncrement: false,
+        },
+        indexes: {
+            key: {
+                unique: true,
+            },
+        },
+    },
+    // settings or other global app properties
+    properties: {
+        key: {
+            keyPath: 'name',
+            autoIncrement: false,
+        },
+        indexes: {
+            key: {
+                unique: true,
+            },
+        },
+    },
+    // Dynamic data, passed by via querystring is stored in a separate table,
+    // because its update mechanism is separate from the survey + resources.
+    // Otherwise the all-or-nothing form+resources update would remove this data.
+    data: {
+        key: {
+            keyPath: 'enketoId',
+            autoIncrement: false,
+        },
+        indexes: {
+            enketoId: {
+                unique: true,
+            },
+        },
+    },
+};
+
+/**
+ * Opens the db.js connection to the enketo database, applying its schema.
+ *
+ * @return { Promise } resolves with the db.js server object
+ */
+function _openDatabase() {
+    return db.open({
+        server: databaseName,
+        version,
+        schema,
+    });
+}
+
+/**
+ * Handles the (rare) event of the underlying IndexedDB connection being closed
+ * unexpectedly, i.e. without `server.close()` having been called. This can happen
+ * e.g. on iOS when the OS aggressively reclaims memory from backgrounded Safari tabs.
+ *
+ * db.js caches the raw `IDBDatabase` connection internally and will keep handing out
+ * this now-unusable connection unless it is told the connection was closed. Explicitly
+ * closing the (already closed) server clears that cache, so the reconnect below opens
+ * a fresh connection instead of reusing the dead one.
+ *
+ * @return { void }
+ */
+function _handleConnectionClose() {
+    available = false;
+
+    console.error(
+        'IndexedDB connection was closed unexpectedly. Attempting to reconnect...'
+    );
+
+    Promise.resolve()
+        .then(() => (server ? server.close() : undefined))
+        .catch(() => {
+            // ignore, the connection is already unusable
+        })
+        .then(_openDatabase)
+        .then((s) => {
+            server = s;
+            _listenForConnectionClose();
+
+            return _isWriteable();
+        })
+        .then(_setBlobStorageEncoding)
+        .then(() => {
+            available = true;
+            console.log('IndexedDB connection was successfully recreated.');
+        })
+        .catch((error) => {
+            console.error('Failed to reconnect to IndexedDB', error);
+        });
+}
+
+/**
+ * Listens for the underlying `IDBDatabase` connection being closed unexpectedly, so
+ * that the connection can be reinitialized. `close` is a native `IDBDatabase` event
+ * that db.js does not support directly, so it is added to the raw connection obtained
+ * via `server.getIndexedDB()`.
+ *
+ * @return { void }
+ */
+function _listenForConnectionClose() {
+    const idb =
+        server && typeof server.getIndexedDB === 'function'
+            ? server.getIndexedDB()
+            : null;
+
+    if (!idb || typeof idb.addEventListener !== 'function') {
+        return;
+    }
+
+    idb.addEventListener('close', _handleConnectionClose, { once: true });
+}
+
 /**
  * @typedef StoreInitOptions
  * @property {boolean} [failSilently]
@@ -95,110 +269,10 @@ function init({ failSilently } = {}) {
                 });
             });
         })
-        .then(() =>
-            db.open({
-                server: databaseName,
-                version,
-                schema: {
-                    // the surveys
-                    surveys: {
-                        key: {
-                            keyPath: 'enketoId',
-                            autoIncrement: false,
-                        },
-                        indexes: {
-                            enketoId: {
-                                unique: true,
-                            },
-                        },
-                    },
-                    // the resources that belong to a survey
-                    resources: {
-                        key: {
-                            autoIncrement: false,
-                        },
-                        indexes: {
-                            key: {
-                                unique: true,
-                            },
-                        },
-                    },
-                    // Records in separate table because it makes more sense for getting, updating and removing records
-                    // if they are not stored in one (giant) array or object value.
-                    // Need to watch out for bad iOS bug: http://www.raymondcamden.com/2014/9/25/IndexedDB-on-iOS-8--Broken-Bad
-                    // but with the current keys there is no risk of using the same key in multiple tables.
-                    // InstanceId is the key because instanceName may change when editing a draft.
-                    records: {
-                        key: {
-                            keyPath: 'instanceId',
-                        },
-                        indexes: {
-                            // https://github.com/enketo/enketo-express/issues/416
-                            recordName: {
-                                keyPath: ['enketoId', 'name'],
-                                unique: true,
-                            },
-                            // the actual key
-                            instanceId: {
-                                unique: true,
-                            },
-                            // to get all records belonging to a form
-                            enketoId: {
-                                unique: false,
-                            },
-                        },
-                    },
-                    lastSavedRecords: {
-                        /**
-                         * @see Note on `records` about unique keys across IndexedDB object stores
-                         */
-                        key: {
-                            keyPath: '_enketoId',
-                            autoIncrement: false,
-                        },
-                    },
-                    // the files that belong to a record
-                    files: {
-                        key: {
-                            autoIncrement: false,
-                        },
-                        indexes: {
-                            key: {
-                                unique: true,
-                            },
-                        },
-                    },
-                    // settings or other global app properties
-                    properties: {
-                        key: {
-                            keyPath: 'name',
-                            autoIncrement: false,
-                        },
-                        indexes: {
-                            key: {
-                                unique: true,
-                            },
-                        },
-                    },
-                    // Dynamic data, passed by via querystring is stored in a separate table,
-                    // because its update mechanism is separate from the survey + resources.
-                    // Otherwise the all-or-nothing form+resources update would remove this data.
-                    data: {
-                        key: {
-                            keyPath: 'enketoId',
-                            autoIncrement: false,
-                        },
-                        indexes: {
-                            enketoId: {
-                                unique: true,
-                            },
-                        },
-                    },
-                },
-            })
-        )
+        .then(_openDatabase)
         .then((s) => {
             server = s;
+            _listenForConnectionClose();
         })
         .then(_isWriteable)
         .then(_setBlobStorageEncoding)

--- a/packages/enketo-express/test/client/records-queue.spec.js
+++ b/packages/enketo-express/test/client/records-queue.spec.js
@@ -253,6 +253,19 @@ describe('Records queue', () => {
                 .then(done, done);
         });
 
+        it('saves a record even when its survey is missing from the form cache', (done) => {
+            // Simulates the survey cache being unavailable, e.g. after an
+            // unexpected IndexedDB connection reset that clears stored data.
+            store.survey
+                .remove(enketoId)
+                .then(() => records.save('set', recordA))
+                .then(() => store.record.get(instanceIdA))
+                .then((record) => {
+                    expect(record.instanceId).to.equal(instanceIdA);
+                })
+                .then(done, done);
+        });
+
         describe('file handling when no auto-saved record exists', () => {
             beforeEach((done) => {
                 // Remove any existing auto-saved record

--- a/packages/enketo-express/test/client/store.spec.js
+++ b/packages/enketo-express/test/client/store.spec.js
@@ -925,4 +925,57 @@ describe('Client Storage', () => {
             expect(caught).to.equal(null);
         });
     });
+
+    describe('reconnecting after an unexpected IndexedDB close', () => {
+        /** @type {import('sinon').SinonSandbox} */
+        let sandbox;
+
+        /** @type {EventTarget} */
+        let fakeIDB;
+
+        /** @type {{ close: import('sinon').SinonStub, getIndexedDB: () => EventTarget, properties: { update: import('sinon').SinonStub } }} */
+        let fakeServer;
+
+        beforeEach(async () => {
+            sandbox = sinon.createSandbox();
+            fakeIDB = new EventTarget();
+            fakeServer = {
+                close: sandbox.stub().resolves(),
+                getIndexedDB: () => fakeIDB,
+                properties: {
+                    update: sandbox
+                        .stub()
+                        .resolves([{ name: 'test', value: 1 }]),
+                },
+            };
+
+            sandbox.stub(db, 'open').resolves(fakeServer);
+
+            await store.init();
+        });
+
+        afterEach(async () => {
+            sandbox.restore();
+
+            // restore a real connection for subsequent tests
+            await store.init();
+        });
+
+        it('marks the store as unavailable as soon as the connection closes', () => {
+            fakeIDB.dispatchEvent(new Event('close'));
+
+            expect(store.available).to.equal(false);
+        });
+
+        it('closes the stale connection and reopens a new one', async () => {
+            fakeIDB.dispatchEvent(new Event('close'));
+
+            // let the reconnect promise chain settle
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(fakeServer.close).to.have.been.calledOnce;
+            expect(db.open).to.have.been.calledTwice;
+            expect(store.available).to.equal(true);
+        });
+    });
 });


### PR DESCRIPTION
### 📣 Summary

Now a IDBDatabase connection that gets closed is automatically restablished


### 💭 Notes
On iOS, when memory is under pressure (e.g. after switching to several memory-heavy apps), Safari can forcibly close a page's IndexedDB connection in the background, even if the Enketo tab stays open. Previously, once this happened, the app kept using the now-dead connection and any attempt to save a draft or submit a form would fail with an error like `Failed to execute 'transaction' on 'IDBDatabase'`, putting users at risk of losing their work. This issue is reported to happen on iOS in situations of high memory usage; it's a rare bug that's hard to reproduce and verify on demand, since it depends on iOS's own memory-reclaim behavior rather than anything within Enketo's control.

This PR detects when the underlying connection is closed unexpectedly and automatically reopens it, so that saving and submitting continue to work without requiring the user to reload the page.

- Added unit tests in [store.spec.js](packages/enketo-express/test/client/store.spec.js) covering the reconnect flow.
- I decided to leave the `console.error` and `console.log` since this is not a common issue and it helps to map an invisible behavior if needed

### 👀 Preview steps

1. ℹ️ Open a form in Enketo and start filling it out (online or offline).
2. Open DevTools → Application → IndexedDB → delete/clear the `enketo` database (simulating iOS force-closing the connection).
3. 🔴 [on main] Continue filling the form and submit/save a draft — this fails with an `IDBDatabase` transaction error and the record may be lost.
4. 🟢 [on PR] Continue filling the form and submit/save a draft — a `IndexedDB connection was closed unexpectedly. Attempting to reconnect...` message appears in the console, followed by `IndexedDB connection was successfully recreated.`, and the save/submit succeeds normally.