### PR TITLE
fix(survey): write openRosaId when updating survey properties

### DIFF
--- a/packages/enketo-express/app/controllers/api-v1-controller.js
+++ b/packages/enketo-express/app/controllers/api-v1-controller.js
@@ -143,7 +143,8 @@ function getNewOrExistingSurvey(req, res, next) {
             id ? surveyModel.get(id) : null
         )
         .catch((error) => {
-            if (error.status === 404) {
+            // 406 = incomplete survey record; let set() below repair it
+            if (error.status === 404 || error.status === 406) {
                 return null;
             }
             throw error;

--- a/packages/enketo-express/app/controllers/api-v2-controller.js
+++ b/packages/enketo-express/app/controllers/api-v2-controller.js
@@ -209,7 +209,8 @@ function getNewOrExistingSurvey(req, res, next) {
             id ? surveyModel.get(id) : null
         )
         .catch((error) => {
-            if (error.status === 404) {
+            // 406 = incomplete survey record; let set() below repair it
+            if (error.status === 404 || error.status === 406) {
                 return null;
             }
             throw error;

--- a/packages/enketo-express/app/models/survey-model.js
+++ b/packages/enketo-express/app/models/survey-model.js
@@ -243,6 +243,10 @@ function _updateProperties(id, survey) {
         if (typeof survey.openRosaServer !== 'undefined') {
             update.openRosaServer = survey.openRosaServer;
         }
+        // also write openRosaId to repair surveys created from a dangling openRosaKey pointer
+        if (typeof survey.openRosaId !== 'undefined') {
+            update.openRosaId = survey.openRosaId;
+        }
         if (typeof survey.active !== 'undefined') {
             update.active = survey.active;
         }

--- a/packages/enketo-express/test/server/api-controller.spec.js
+++ b/packages/enketo-express/test/server/api-controller.spec.js
@@ -6,6 +6,7 @@ process.env.NODE_ENV = 'test';
  * at http://apidocs.enketo.org.
  */
 const request = require('supertest');
+const { expect } = require('chai');
 const config = require('../../app/models/config-model').server;
 
 config['base path'] = '';
@@ -13,6 +14,7 @@ const app = require('../../config/express');
 const surveyModel = require('../../app/models/survey-model');
 const instanceModel = require('../../app/models/instance-model');
 const cacheModel = require('../../app/models/cache-model');
+const { mainClient } = require('../../app/lib/db');
 
 let v1Survey;
 let v1Instance;
@@ -1342,6 +1344,39 @@ describe('api', () => {
                 return obj;
             })
             .forEach(testResponse);
+    });
+
+    describe('repairing surveys that are missing openRosaId', () => {
+        function test(version) {
+            it(`v${version}: POST /survey completes the survey record`, async () => {
+                const endpoint = `/api/v${version}/survey`;
+                const id = await surveyModel.getId({
+                    openRosaServer: validServer,
+                    openRosaId: validFormId,
+                });
+                await new Promise((resolve, reject) => {
+                    mainClient.hdel(`id:${id}`, 'openRosaId', (error) =>
+                        error ? reject(error) : resolve(undefined)
+                    );
+                });
+
+                return request(app)
+                    .post(endpoint)
+                    .set(validAuth)
+                    .send({
+                        server_url: validServer,
+                        form_id: validFormId,
+                    })
+                    .expect(201)
+                    .then(() => surveyModel.get(id))
+                    .then((survey) =>
+                        expect(survey.openRosaId).to.equal(validFormId)
+                    );
+            });
+        }
+
+        test('1');
+        test('2');
     });
 
     describe('re-activating forms', () => {

--- a/packages/enketo-express/test/server/survey-model.spec.js
+++ b/packages/enketo-express/test/server/survey-model.spec.js
@@ -5,6 +5,7 @@ const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const config = require('../../app/models/config-model').server;
 const model = require('../../app/models/survey-model');
+const { mainClient } = require('../../app/lib/db');
 
 chai.use(chaiAsPromised);
 
@@ -281,6 +282,27 @@ describe('Survey Model', () => {
                 expect(promise)
                     .to.eventually.have.property('theme')
                     .and.to.equal('different'),
+            ]);
+        });
+
+        it('returns the (openRosaId restored) survey object when the record only exists as a pointer and called via set()', () => {
+            const danglingId = 'dangl1ng';
+            const promise = new Promise((resolve, reject) => {
+                mainClient.set(
+                    `or:ona.io/enketo,${survey.openRosaId}`,
+                    danglingId,
+                    (error) => (error ? reject(error) : resolve(undefined))
+                );
+            })
+                .then(() => model.set(survey))
+                .then(model.get);
+            return Promise.all([
+                expect(promise)
+                    .to.eventually.have.property('enketoId')
+                    .and.to.equal(danglingId),
+                expect(promise)
+                    .to.eventually.have.property('openRosaId')
+                    .and.to.equal(survey.openRosaId),
             ]);
         });
     });


### PR DESCRIPTION
Fixes #1582.

### 📣 Summary

Form links that stopped working with a "Survey information for this id is incomplete" error now repair themselves the next time the form is opened.

### 👷 Description for integrators

`_updateProperties` deliberately omits `openRosaId` from the fields it writes, but `HMSET` creates the survey hash when it does not exist. So when an `or:<server>,<openRosaId>` key exists without its matching `id:<enketoId>` hash — which can happen after a partial write or data loss in Redis — `setSurvey` resolves the pointer, takes the "already exists" branch, and `_updateProperties` materializes a survey hash containing only `openRosaServer`/`active`/`theme`. Such a record fails `getSurvey`'s completeness check with a 406 on every subsequent request, and nothing ever repairs it.

This PR includes `openRosaId` in the update, mirroring the existing `openRosaServer` handling:

- Both callers (`setSurvey`, `updateSurvey`) reject via `utils.getOpenRosaKey` unless `openRosaId` is present, so it is always defined here.
- Its value is by construction the same `openRosaId` encoded in the `or:` key that resolved to this enketo id, so for a healthy record the write is a no-op.

A survey record missing its `openRosaId` is now completed on the next survey request instead of staying broken.

### 💭 Notes

- We hit this in production: a set of survey records stuck permanently on the 406, each missing `openRosaId` (and `launchDate`/`submissions`, showing they were materialized by `_updateProperties` rather than created by `_addSurvey`).
- New test reproduces the failure mode: an `or:` pointer to a non-existent survey hash → `set()` → `get()` resolves with the correct `openRosaId`/`enketoId`. It fails without the fix and passes with it (verified in both directions).
- `survey-model.spec.js` passes 33/33 locally against the self-contained Redis test harness.
- Regression risk is limited to `_updateProperties`: the only behavior change is one additional field in the `HMSET`, with a value that is already guaranteed present and consistent by both callers.

### 👀 Preview steps

1. ℹ️ have a form published to enketo (its `id:<enketoId>` hash and `or:` key exist in the main Redis db)
2. in redis-cli: `HDEL id:<enketoId> openRosaId` (simulates the broken state)
3. open the form's enketo link
4. 🔴 [on main] the link fails with 406 "Survey information for this id is incomplete", on this and every later attempt
5. 🟢 [on PR] re-publish/relaunch the form (triggering a survey API request); the record is completed and the link works again