### PR TITLE
fix(offline): do not intercept non-GET requests in the offline app service worker DEV-2598

### DIFF
--- a/packages/enketo-express/public/js/src/module/offline-app-worker-partial.js
+++ b/packages/enketo-express/public/js/src/module/offline-app-worker-partial.js
@@ -60,13 +60,7 @@ self.addEventListener('message', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
-    // Only intervene for GET requests, which is all that is ever cached.
-    // Re-constructing a Request/Response for non-GET requests (e.g. the
-    // multipart/form-data POST used for submissions, which can carry large
-    // file Blobs) through `fetch(event.request, {...})` is not needed here
-    // and is known to be unreliable in some browsers (notably Safari/WebKit),
-    // which can silently send an empty body. Letting the browser handle
-    // those requests natively avoids that risk entirely.
+    // Non-GET requests (e.g. form submissions) are not cached and should not be intercepted.
     if (event.request.method !== 'GET') {
         return;
     }

--- a/packages/enketo-express/public/js/src/module/offline-app-worker-partial.js
+++ b/packages/enketo-express/public/js/src/module/offline-app-worker-partial.js
@@ -60,6 +60,17 @@ self.addEventListener('message', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
+    // Only intervene for GET requests, which is all that is ever cached.
+    // Re-constructing a Request/Response for non-GET requests (e.g. the
+    // multipart/form-data POST used for submissions, which can carry large
+    // file Blobs) through `fetch(event.request, {...})` is not needed here
+    // and is known to be unreliable in some browsers (notably Safari/WebKit),
+    // which can silently send an empty body. Letting the browser handle
+    // those requests natively avoids that risk entirely.
+    if (event.request.method !== 'GET') {
+        return;
+    }
+
     event.respondWith(
         caches.match(event.request).then((response) => {
             if (response) {


### PR DESCRIPTION
### 📣 Summary

Non GET fetch actions are not intercepted by offline server worker anymore, avoiding a bug in iOS Webkit browsers.

### 💭 Notes

The service worker's fetch handler intercepted every request in its scope, including the multipart/form-data POST used for submissions (which can carry large file Blobs). Re-constructing that request via fetch(event.request, {...}) is unreliable in some browsers (notably Safari/WebKit) and can silently send an empty body, producing corrupted submissions (empty XML and empty file attachments) that were confirmed both via a captured production request and local reproduction.

There is nothing to cache for non-GET requests anyway, so skip interception for them entirely and let the browser handle them natively.

### 👀 Preview steps

For the issue to be reproduced HTTPS is needed, or else iOS browsers won't start the service workers, what will not cause the bug.