### PR TITLE
chore(release): prepare 7.6.4 release DEV-2653

### DIFF
--- a/examples/enketo-transformer-web/package.json
+++ b/examples/enketo-transformer-web/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@solidjs/router": "^0.16.1",
         "babel-preset-solid": "^1.9.12",
-        "enketo-transformer": "4.3.1",
+        "enketo-transformer": "4.4.0",
         "solid-js": "^1.9.13",
         "vite-plugin-solid": "^2.11.12"
     }

--- a/packages/enketo-core/CHANGELOG.md
+++ b/packages/enketo-core/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [9.0.6] - 2026-08-07
+
+### Added
+
+- Support for HEIC/HEIF file extensions in filepicker and draw widgets (DEV-2396, #1571)
+
+### Security
+
+- Bump library versions: vitest → 4.x, vite → 6.x, node-sass → sass, markdown-it → 14.x, undici → 6.x (DEV-2423, #1572)
+
 ## [9.0.5] - 2026-07-02
 
 ### Fixed

--- a/packages/enketo-core/CHANGELOG.md
+++ b/packages/enketo-core/CHANGELOG.md
@@ -7,11 +7,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Support for HEIC/HEIF file extensions in filepicker and draw widgets (DEV-2396, #1571)
+- Support for HEIC/HEIF file extensions in filepicker and draw widgets (#1571)
+- Support for dynamic readonly expressions, allowing readonly state to change based on XPath expressions as data changes (#1588)
+- Allow configuring Leaflet tile layer `referrerPolicy` option for geopicker maps (#1565)
+
+### Fixed
+
+- Google Maps tiles failing to load due to a `leaflet.gridlayer.googlemutant` incompatibility with `leaflet` 1.9.4 (#1564)
 
 ### Security
 
-- Bump library versions: vitest → 4.x, vite → 6.x, node-sass → sass, markdown-it → 14.x, undici → 6.x (DEV-2423, #1572)
+- Bump library versions: vitest → 4.x, vite → 6.x, node-sass → sass, markdown-it → 14.x, undici → 6.x (#1572)
 
 ## [9.0.5] - 2026-07-02
 

--- a/packages/enketo-core/CHANGELOG.md
+++ b/packages/enketo-core/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Google Maps tiles failing to load due to a `leaflet.gridlayer.googlemutant` incompatibility with `leaflet` 1.9.4 (#1564)
+- Image previews not showing for photo/file widgets (#1592)
 
 ### Security
 

--- a/packages/enketo-core/package.json
+++ b/packages/enketo-core/package.json
@@ -2,7 +2,7 @@
     "name": "enketo-core",
     "description": "Extensible Enketo form engine",
     "homepage": "https://enketo.org",
-    "version": "9.0.5",
+    "version": "9.0.6",
     "license": "Apache-2.0",
     "os": [
         "darwin",

--- a/packages/enketo-core/package.json
+++ b/packages/enketo-core/package.json
@@ -34,7 +34,7 @@
         "test-watch": "cross-env NODE_OPTIONS='--max-old-space-size=8192' grunt test:watch"
     },
     "devDependencies": {
-        "enketo-transformer": "4.3.1",
+        "enketo-transformer": "4.4.0",
         "libxslt": "0.10.2"
     },
     "resolutions": {

--- a/packages/enketo-core/src/js/form.js
+++ b/packages/enketo-core/src/js/form.js
@@ -1610,6 +1610,6 @@ Form.prototype.goToTarget = function (target, options = {}) {
  * @type {string}
  * @default
  */
-Form.requiredTransformerVersion = '4.3.1';
+Form.requiredTransformerVersion = '4.4.0';
 
 export { Form, FormModel };

--- a/packages/enketo-express/CHANGELOG.md
+++ b/packages/enketo-express/CHANGELOG.md
@@ -7,15 +7,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Support for HEIC/HEIF file extensions in filepicker and draw widgets (DEV-2396, #1571)
+- Support for HEIC/HEIF file extensions in filepicker and draw widgets (#1571)
+- Support for dynamic readonly expressions, allowing readonly state to change based on XPath expressions as data changes (#1588)
+- Allow configuring Leaflet tile layer `referrerPolicy` option for geopicker maps (#1565)
 
 ### Fixed
 
-- Service worker no longer intercepts non-GET requests, fixing submission corruption on iOS/Safari (DEV-2598, #1584)
+- Service worker no longer intercepts non-GET requests, fixing submission corruption on iOS/Safari (#1584)
+- Google Maps tiles failing to load due to a `leaflet.gridlayer.googlemutant` incompatibility with `leaflet` 1.9.4 (#1564)
+- OpenSans fonts triggering glyph bbox warnings in Firefox; also reduces font file size (#1566)
 
 ### Security
 
-- Bump library versions: vitest → 4.x, vite → 6.x, node-sass → sass, markdown-it → 14.x, undici → 6.x (DEV-2423, #1572)
+- Bump library versions: vitest → 4.x, vite → 6.x, node-sass → sass, markdown-it → 14.x, undici → 6.x (#1572)
+- Remove `X-Powered-By: Express` response header to reduce fingerprinting (#1567)
 
 ## 7.6.3 - 2026-07-02
 

--- a/packages/enketo-express/CHANGELOG.md
+++ b/packages/enketo-express/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 7.6.4 - 2026-08-07
+
+### Added
+
+- Support for HEIC/HEIF file extensions in filepicker and draw widgets (DEV-2396, #1571)
+
+### Fixed
+
+- Service worker no longer intercepts non-GET requests, fixing submission corruption on iOS/Safari (DEV-2598, #1584)
+
+### Security
+
+- Bump library versions: vitest → 4.x, vite → 6.x, node-sass → sass, markdown-it → 14.x, undici → 6.x (DEV-2423, #1572)
+
 ## 7.6.3 - 2026-07-02
 
 ### Fixed

--- a/packages/enketo-express/CHANGELOG.md
+++ b/packages/enketo-express/CHANGELOG.md
@@ -10,12 +10,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Support for HEIC/HEIF file extensions in filepicker and draw widgets (#1571)
 - Support for dynamic readonly expressions, allowing readonly state to change based on XPath expressions as data changes (#1588)
 - Allow configuring Leaflet tile layer `referrerPolicy` option for geopicker maps (#1565)
+- IndexedDB schema and auto-reconnection logic for offline record storage (DEV-2436, #1576)
 
 ### Fixed
 
 - Service worker no longer intercepts non-GET requests, fixing submission corruption on iOS/Safari (#1584)
 - Google Maps tiles failing to load due to a `leaflet.gridlayer.googlemutant` incompatibility with `leaflet` 1.9.4 (#1564)
 - OpenSans fonts triggering glyph bbox warnings in Firefox; also reduces font file size (#1566)
+- Image previews not showing for photo/file widgets (DEV-2658, #1592)
 
 ### Security
 

--- a/packages/enketo-express/package.json
+++ b/packages/enketo-express/package.json
@@ -35,7 +35,7 @@
         "db.js": "^0.15.0",
         "debug": "^4.3.4",
         "enketo-core": "9.0.6",
-        "enketo-transformer": "4.3.1",
+        "enketo-transformer": "4.4.0",
         "evp_bytestokey": "^1.0.3",
         "express": "^4.21.2",
         "express-cls-hooked": "^0.3.8",

--- a/packages/enketo-express/package.json
+++ b/packages/enketo-express/package.json
@@ -34,7 +34,7 @@
         "csurf": "^1.11.0",
         "db.js": "^0.15.0",
         "debug": "^4.3.4",
-        "enketo-core": "9.0.5",
+        "enketo-core": "9.0.6",
         "enketo-transformer": "4.3.1",
         "evp_bytestokey": "^1.0.3",
         "express": "^4.21.2",

--- a/packages/enketo-express/package.json
+++ b/packages/enketo-express/package.json
@@ -2,7 +2,7 @@
     "name": "enketo-express",
     "description": "Webforms evolved.",
     "homepage": "https://enketo.org",
-    "version": "7.6.3",
+    "version": "7.6.4",
     "main": "./app.js",
     "repository": {
         "type": "git",

--- a/packages/enketo-transformer/CHANGELOG.md
+++ b/packages/enketo-transformer/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.4.0] - 2026-08-07
+
+### Added
+
+- Generate a `data-readonly` attribute for readonly XPath expressions in `openrosa2html5form.xsl`, enabling dynamic readonly support in `enketo-core` (#1588)
+
 ## [4.3.1] - 2025-06-05
 
 ### Technical

--- a/packages/enketo-transformer/package.json
+++ b/packages/enketo-transformer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "enketo-transformer",
-    "version": "4.3.1",
+    "version": "4.4.0",
     "description": "Library that transforms ODK-compliant XForms into a format that Enketo can consume",
     "license": "Apache-2.0",
     "type": "module",


### PR DESCRIPTION
## 7.6.4 - 2026-08-11

The changes this covers are [7.6.3...7.6.4](https://github.com/enketo/enketo/compare/release/7.6.3...dev-2598-prepare-release-7.6.4)

## Summary

This is a patch release with new features, several bug fixes, and security dependency updates:

- `enketo-core`: 9.0.5 → 9.0.6 (dynamic readonly expressions, configurable geopicker referrerPolicy, HEIC/HEIF support, Google Maps fix, image preview fix, security dep bumps)
- `enketo-express`: 7.6.3 → 7.6.4 (iOS submission fix, OpenSans font fix, X-Powered-By header removed, IndexedDB reconnection, image preview fix, plus all enketo-core changes above)
- `enketo-transformer`: 4.3.1 → 4.4.0 (generates `data-readonly` attribute to support dynamic readonly expressions)

`openrosa-xpath-evaluator` remains unchanged in this release.

## Key Changes

### Added

- Support for dynamic readonly expressions, allowing readonly state to change based on XPath expressions as data changes ([#1588](https://github.com/enketo/enketo/pull/1588), originally [#1457](https://github.com/enketo/enketo/pull/1457))
- Support for HEIC/HEIF file extensions in filepicker and draw widgets ([#1571](https://github.com/enketo/enketo/pull/1571))
- Allow configuring Leaflet tile layer `referrerPolicy` option for geopicker maps ([#1565](https://github.com/enketo/enketo/pull/1565))
- IndexedDB schema and auto-reconnection logic for offline record storage ([#1576](https://github.com/enketo/enketo/pull/1576))

### Fixed

- Service worker no longer intercepts non-GET requests, fixing corrupted submissions on iOS/Safari ([#1584](https://github.com/enketo/enketo/pull/1584))
- Google Maps tiles failing to load due to a `leaflet.gridlayer.googlemutant` incompatibility with `leaflet` 1.9.4 ([#1564](https://github.com/enketo/enketo/pull/1564))
- OpenSans fonts triggering glyph bbox warnings in Firefox; also reduces font file size ([#1566](https://github.com/enketo/enketo/pull/1566))
- Image previews not showing for photo/file widgets ([#1592](https://github.com/enketo/enketo/pull/1592))

### Security

- Bump library versions: vitest → 4.x, vite → 6.x, node-sass → sass 1.99.0, markdown-it → 14.x, undici → 6.x ([#1572](https://github.com/enketo/enketo/pull/1572))
- Remove `X-Powered-By: Express` response header to reduce fingerprinting ([#1567](https://github.com/enketo/enketo/pull/1567))

### Chores

- Fix broken `if` condition syntax in the Dependabot auto-merge GitHub Actions workflow (CI-only, no package changes) ([#1568](https://github.com/enketo/enketo/pull/1568))

## Breaking Changes

None in this release — all changes are backward compatible.

## Contributors

- @pauloamorimbr
- @alxndrsn (#1564, #1565, #1566, #1567, #1568)
- @iahmedani / Imran Khan (#1588, originally #1457)