### PR TITLE
feat(core): implement dynamic readonly expressions support DEV-2655

### DIFF
--- a/packages/enketo-core/src/js/input.js
+++ b/packages/enketo-core/src/js/input.js
@@ -140,9 +140,17 @@ export default {
     },
     /**
      * @param {Element} control - form control HTML element
-     * @return {boolean} whether element is read only
+     * @return {string|boolean} readonly expression or boolean
      */
     getReadonly(control) {
+        const { readonly } = control.dataset;
+
+        // If data-readonly attribute exists, return the expression
+        if (readonly != null) {
+            return readonly;
+        }
+
+        // Fall back to checking for static readonly attribute (backward compatibility)
         return control.matches('[readonly]');
     },
     /**

--- a/packages/enketo-core/src/js/nodeset.js
+++ b/packages/enketo-core/src/js/nodeset.js
@@ -401,6 +401,22 @@ Nodeset.prototype.isRequired = function (expr) {
 };
 
 /**
+ * @param {string} [expr] - The XPath expression
+ * @return {boolean} Whether node is readonly
+ */
+Nodeset.prototype.isReadonly = function (expr) {
+    return !expr || expr.trim() === 'false()'
+        ? false
+        : expr.trim() === 'true()' ||
+              this.model.evaluate(
+                  expr,
+                  'boolean',
+                  this.originalSelector,
+                  this.index
+              );
+};
+
+/**
  * Validates if requiredness is fulfilled.
  *
  * @param {string} [expr] - The XPath expression

--- a/packages/enketo-core/src/js/readonly.js
+++ b/packages/enketo-core/src/js/readonly.js
@@ -20,14 +20,61 @@ export default {
      * @param {UpdatedDataNodes} [updated] - The object containing info on updated data nodes.
      */
     update(updated) {
-        const nodes = this.form.getRelatedNodes('readonly', '', updated).get();
+        const that = this;
+        const readonlyCache = {};
+
+        // Get nodes with both static readonly attribute and dynamic data-readonly attribute
+        const staticNodes = this.form
+            .getRelatedNodes('readonly', '', updated)
+            .get();
+        const dynamicNodes = this.form
+            .getRelatedNodes('data-readonly', '', updated)
+            .get();
+
+        // Combine both sets of nodes, removing duplicates
+        const allNodes = [...new Set([...staticNodes, ...dynamicNodes])];
 
         const { valueChanged } = this.form.collections.actions;
 
-        nodes.forEach((node) => {
-            node.closest('.question').classList.add('readonly');
+        allNodes.forEach((node) => {
+            const input = node;
+            const readonlyExpr = that.form.input.getReadonly(input);
+            const path = that.form.input.getName(input);
 
-            const path = this.form.input.getName(node);
+            let isReadonly;
+
+            // If readonlyExpr is a string (dynamic expression), evaluate it
+            if (typeof readonlyExpr === 'string') {
+                const index = that.form.input.getIndex(input);
+                // Use caching similar to required.js for performance
+                const cacheIndex = `${readonlyExpr}__${path.substring(
+                    0,
+                    path.lastIndexOf('/')
+                )}__${index}`;
+
+                if (typeof readonlyCache[cacheIndex] === 'undefined') {
+                    readonlyCache[cacheIndex] = that.form.model
+                        .node(path, index)
+                        .isReadonly(readonlyExpr);
+                }
+
+                isReadonly = readonlyCache[cacheIndex];
+            } else {
+                // readonlyExpr is a boolean (static readonly attribute check)
+                isReadonly = readonlyExpr;
+            }
+
+            const $question = node.closest('.question');
+
+            // Apply or remove readonly state
+            if (isReadonly) {
+                $question.classList.add('readonly');
+                node.setAttribute('readonly', 'readonly');
+            } else {
+                $question.classList.remove('readonly');
+                node.removeAttribute('readonly');
+            }
+
             const action = valueChanged?.hasRef(path);
 
             // Note: the readonly-forced class is added for special readonly views of a form.
@@ -37,9 +84,9 @@ export default {
                 !action &&
                 !node.classList.contains('readonly-forced');
 
-            node.classList.toggle('empty', empty);
+            node.classList.toggle('empty', empty && isReadonly);
 
-            if (empty) {
+            if (empty && isReadonly) {
                 node.setAttribute('aria-hidden', 'true');
             } else {
                 node.removeAttribute('aria-hidden');

--- a/packages/enketo-transformer/src/xsl/openrosa2html5form.xsl
+++ b/packages/enketo-transformer/src/xsl/openrosa2html5form.xsl
@@ -1150,6 +1150,11 @@ XSLT Stylesheet that transforms OpenRosa style (X)Forms into valid HTMl5 forms
             -->
             <xsl:attribute name="readonly">readonly</xsl:attribute>
         </xsl:if>
+        <xsl:if test="(string-length($binding/@readonly) &gt; 0) and not($binding/@readonly = 'false()') and not($html-input-type = 'hidden') and not(local-name() = 'bind')">
+            <xsl:attribute name="data-readonly">
+                <xsl:value-of select="$binding/@readonly" />
+            </xsl:attribute>
+        </xsl:if>
         <xsl:if test="local-name() = 'range'">
         <!-- note that due to the unhelpful default value behavior of input type=range in HTML, we use type=number -->
             <xsl:if test="@start">

--- a/packages/enketo-transformer/test/external-fixtures/enketo-core/readonly-dynamic.xml
+++ b/packages/enketo-transformer/test/external-fixtures/enketo-core/readonly-dynamic.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>readonly-dynamic</h:title>
+    <model>
+      <instance>
+        <readonly-dynamic id="readonly-dynamic">
+          <status>locked</status>
+          <field1></field1>
+          <field2></field2>
+          <count>0</count>
+          <field3></field3>
+          <meta>
+            <instanceID/>
+          </meta>
+        </readonly-dynamic>
+      </instance>
+      <bind nodeset="/readonly-dynamic/status" type="string"/>
+      <bind nodeset="/readonly-dynamic/field1" readonly="./status = 'locked'" type="string"/>
+      <bind nodeset="/readonly-dynamic/field2" readonly="../status = 'locked'" type="string"/>
+      <bind nodeset="/readonly-dynamic/count" type="int"/>
+      <bind nodeset="/readonly-dynamic/field3" readonly="/readonly-dynamic/count > 5" type="string"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/readonly-dynamic/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/readonly-dynamic/status">
+      <label>Status (type "locked" to make fields readonly)</label>
+    </input>
+    <input ref="/readonly-dynamic/field1">
+      <label>Field 1 (readonly when status = locked, using relative path)</label>
+    </input>
+    <input ref="/readonly-dynamic/field2">
+      <label>Field 2 (readonly when status = locked, using parent path)</label>
+    </input>
+    <input ref="/readonly-dynamic/count">
+      <label>Count (enter a number > 5 to make field3 readonly)</label>
+    </input>
+    <input ref="/readonly-dynamic/field3">
+      <label>Field 3 (readonly when count > 5)</label>
+    </input>
+  </h:body>
+</h:html>


### PR DESCRIPTION
This PR is a rewrite of #1457 to add the test snapshot update before merge.
---

### 📣 Summary

Form fields can now become readonly or editable dynamically based on XPath expressions that evaluate as data changes, just like required, relevant, and calculate fields already work.

### 📖 Description

Previously, fields could only be marked as permanently readonly using `readonly="true()"`. They would stay readonly for the entire session, which limited form flexibility.

Now, readonly status can change dynamically based on conditions in your form. For example:
- A field becomes readonly after a form is approved or locked
- Fields become readonly when certain conditions are met (e.g., when a count reaches a threshold)
- Fields can be conditionally editable based on user roles or status values

This works using XPath expressions like `readonly="./status = 'locked'"` or `readonly="count(../items) > 0"`, matching how required and relevant fields have always worked.

**How this affects users:**
- More flexible forms without workarounds
- Simpler form logic for conditional editing permissions
- Better support for progressive form locking workflows
- Reduced need for complex branching logic to hide/show fields

### 👷 Description for integrators

This implements dynamic readonly expression evaluation following the established architectural pattern used by `required`, `relevant`, and `calculate` attributes.

**Implementation changes:**

1. **Transformer** (`openrosa2html5form.xsl`): Now generates `data-readonly` attribute containing XPath expressions for all readonly bindings
2. **Model layer** (`nodeset.js`): Added `isReadonly(expr)` method that evaluates boolean XPath expressions against the data model
3. **Input layer** (`input.js`): Updated `getReadonly()` to return expression strings from `data-readonly` attribute, with fallback to static readonly check
4. **Readonly module** (`readonly.js`): Rewrote `update()` to evaluate dynamic expressions and apply/remove readonly state based on evaluation results

**Key features:**
- Expression caching for performance (pattern from `required.js`)
- Backward compatible with static `readonly="true()"`
- Participates in the evaluation cascade like other dynamic attributes
- No breaking changes to existing APIs or forms

**XForm example:**
```xml
<bind nodeset="/data/field1" readonly="./status = 'locked'" type="string"/>
<bind nodeset="/data/field2" readonly="count(../items) > 0" type="string"/>
```

### 💭 Notes

This supersedes #1457 — all credit for the design and implementation goes to **@iahmedani (Imran Khan)**, who authored the original PR. That PR was opened against an old base (release 7.6.0) and had since drifted far behind `main`, with a genuine failing CI check (`test-transformer (Web, 22.12.0, Firefox)`).

What this PR does on top of that:
- Cherry-picks `iahmedani`'s single commit (`b59136c4` from #1457) onto current `main`, preserving their authorship on that commit.
- Adds one additional commit (mine) updating ~400 transformer snapshot fixtures to account for the new `data-readonly` attribute now also being emitted for existing static `readonly="true()"` bindings — a mechanical, purely additive fallout of the feature, not a behavior change.
- Verified `yarn lint` (0 errors), `enketo-transformer` vitest suite (2035 passed, 4 expected-fail, 2 skipped), and `enketo-core` karma suite (only the 3 pre-existing/documented baseline failures, unrelated to this change) all pass on top of current `main`.

Closes: #375 (originally requested in 2016)
Closes: #1457 (superseded by this PR)

Files changed:
- `packages/enketo-transformer/src/xsl/openrosa2html5form.xsl` (+5 lines)
- `packages/enketo-core/src/js/nodeset.js` (+16 lines)
- `packages/enketo-core/src/js/input.js` (+10 lines)
- `packages/enketo-core/src/js/readonly.js` (+59 lines, -7 lines)
- `packages/enketo-transformer/test/external-fixtures/enketo-core/readonly-dynamic.xml` (new test form)
- `packages/enketo-transformer/test/__snapshots__/snapshot.spec.ts.snap` (snapshot update, this PR only)

**Regression risk:** Low - maintains full backward compatibility. Static `readonly="true()"` continues to work identically; both static `readonly` and `data-readonly` attributes are processed.

### 👀 Preview steps

ℹ️ Use the included test form `packages/enketo-transformer/test/external-fixtures/enketo-core/readonly-dynamic.xml` or create a form with a dynamic readonly binding:

```xml
<bind nodeset="/data/status" type="string"/>
<bind nodeset="/data/field1" readonly="./status = 'locked'" type="string"/>
```

1. Load the form in Enketo
2. 🟢 [on PR] Initially, the status field is empty and field1 is editable (not readonly)
3. 🟢 [on PR] Type "locked" in the status field
4. 🟢 [on PR] Notice field1 immediately becomes readonly (grayed out, not editable)
5. 🟢 [on PR] Change status to anything else (e.g., "unlocked")
6. 🟢 [on PR] Notice field1 becomes editable again
7. 🔴 [on main] The same form would ignore the readonly expression entirely - field1 would remain editable regardless of status value

Additional test case for numeric expressions:
- Use binding: `<bind nodeset="/data/count" type="int"/>` and `<bind nodeset="/data/field2" readonly="/data/count > 5" type="string"/>`
- 🟢 [on PR] When count ≤ 5, field2 is editable
- 🟢 [on PR] When count > 5, field2 becomes readonly
- 🔴 [on main] field2 would always be editable
