### PR TITLE
enketo-express: add exp/iat claims to JWTs and handle expiry on decode

### DIFF
--- a/packages/enketo-express/app/controllers/authentication-controller.js
+++ b/packages/enketo-express/app/controllers/authentication-controller.js
@@ -94,10 +94,17 @@ function setToken(req, res) {
     const maxAge = 30 * 24 * 60 * 60 * 1000;
     const returnUrl = req.query.return_url || '';
 
+    const nowSecs = Math.floor(Date.now() / 1000);
+    const expSecs = req.body.remember
+        ? nowSecs + 30 * 24 * 60 * 60
+        : nowSecs + 24 * 60 * 60;
+
     const token = jwt.encode(
         {
             user: username,
             pass: req.body.password,
+            iat: nowSecs,
+            exp: expSecs,
         },
         req.app.get('encryption key')
     );

--- a/packages/enketo-express/app/models/user-model.js
+++ b/packages/enketo-express/app/models/user-model.js
@@ -22,9 +22,13 @@ function getCredentials(req) {
     if (authType === 'basic') {
         const jwToken =
             req.signedCookies[req.app.get('authentication cookie name')];
-        creds = jwToken
-            ? jwt.decode(jwToken, req.app.get('encryption key'))
-            : null;
+        try {
+            creds = jwToken
+                ? jwt.decode(jwToken, req.app.get('encryption key'))
+                : null;
+        } catch (e) {
+            creds = null;
+        }
     } else if (authType === 'token') {
         const paramName = auth['query parameter'];
         if (!paramName) {

--- a/packages/enketo-express/test/server/user-model.spec.js
+++ b/packages/enketo-express/test/server/user-model.spec.js
@@ -1,0 +1,69 @@
+process.env.NODE_ENV = 'test';
+
+const jwt = require('jwt-simple');
+const chai = require('chai');
+
+const { expect } = chai;
+
+const encryptionKey = 's0m3v3rys3cr3tk3y';
+
+function makeMockReq(token) {
+    return {
+        app: {
+            get(key) {
+                if (key === 'linked form and data server') {
+                    return { authentication: { type: 'basic' } };
+                }
+                if (key === 'authentication cookie name') {
+                    return '__enketo';
+                }
+                if (key === 'encryption key') {
+                    return encryptionKey;
+                }
+            },
+        },
+        signedCookies: { __enketo: token },
+    };
+}
+
+const { getCredentials } = require('../../app/models/user-model');
+
+describe('user-model', () => {
+    describe('getCredentials', () => {
+        it('returns credentials for a valid non-expired token', () => {
+            const nowSecs = Math.floor(Date.now() / 1000);
+            const token = jwt.encode(
+                { user: 'alice', pass: 'secret', iat: nowSecs, exp: nowSecs + 3600 },
+                encryptionKey
+            );
+            const creds = getCredentials(makeMockReq(token));
+            expect(creds).to.deep.include({ user: 'alice', pass: 'secret' });
+        });
+
+        it('returns null for an expired token', () => {
+            const pastSecs = Math.floor(Date.now() / 1000) - 7200;
+            const token = jwt.encode(
+                { user: 'alice', pass: 'secret', iat: pastSecs - 3600, exp: pastSecs },
+                encryptionKey
+            );
+            const creds = getCredentials(makeMockReq(token));
+            expect(creds).to.equal(null);
+        });
+
+        it('returns credentials for a legacy token without exp (backward-compatible)', () => {
+            const token = jwt.encode(
+                { user: 'alice', pass: 'secret' },
+                encryptionKey
+            );
+            const creds = getCredentials(makeMockReq(token));
+            expect(creds).to.deep.include({ user: 'alice', pass: 'secret' });
+        });
+
+        it('returns null when no cookie is present', () => {
+            const req = makeMockReq(undefined);
+            req.signedCookies.__enketo = undefined;
+            const creds = getCredentials(req);
+            expect(creds).to.equal(null);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Addresses #1589.

JWTs generated at login had no expiration claim, meaning a leaked or stolen token was valid indefinitely. This PR:

- Adds `iat` and `exp` claims to the JWT payload in `setToken()`:
  - **"Remember me"** sessions: `exp` = 30 days (matching the existing cookie `maxAge`)
  - **Session-only** logins: `exp` = 24 hours
- Wraps `jwt.decode()` in `getCredentials()` with a try/catch so that an expired token (or any other decode error) is treated as absent credentials rather than propagating an unhandled exception. `jwt-simple` already enforces the `exp` claim on decode.
- Adds `test/server/user-model.spec.js` covering:
  - Valid non-expired token → credentials returned
  - Expired token → `null` (no throw)
  - Legacy token without `exp` → still decoded (backward-compatible)
  - Missing cookie → `null`

**Out of scope:** Token refresh and JWT encryption (#1590) are left as separate follow-ups per the issue discussion.

## Test plan

- [ ] Run `npm run test-server` in `packages/enketo-express` — all tests pass including the new `user-model.spec.js`
- [ ] Log in with "remember me" → decode the cookie JWT → confirm `exp` ≈ now + 30 days
- [ ] Log in without "remember me" → confirm `exp` ≈ now + 24 hours
- [ ] Manually set a cookie with an expired JWT → confirm the request is treated as unauthenticated (401/redirect to login), not a 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)