### PR TITLE
enketo-express: encrypt auth JWTs (JWS → JWE)

### DIFF
--- a/packages/enketo-express/app/controllers/authentication-controller.js
+++ b/packages/enketo-express/app/controllers/authentication-controller.js
@@ -5,7 +5,8 @@
 const csrfProtection = require('csurf')({
     cookie: true,
 });
-const jwt = require('jwt-simple');
+const { EncryptJWT } = require('jose');
+const { deriveEncryptionKey } = require('../lib/encryption');
 const express = require('express');
 
 const router = express.Router();
@@ -88,19 +89,28 @@ function logout(req, res) {
 /**
  * @param {module:api-controller~ExpressRequest} req - HTTP request
  * @param {module:api-controller~ExpressResponse} res - HTTP response
+ * @param {Function} next - Express callback
  */
-function setToken(req, res) {
+async function setToken(req, res, next) {
     const username = req.body.username.trim();
     const maxAge = 30 * 24 * 60 * 60 * 1000;
     const returnUrl = req.query.return_url || '';
 
-    const token = jwt.encode(
-        {
-            user: username,
-            pass: req.body.password,
-        },
-        req.app.get('encryption key')
-    );
+    let token;
+    try {
+        const derivedKey = deriveEncryptionKey(req.app.get('encryption key'));
+        const nowSecs = Math.floor(Date.now() / 1000);
+        const expSecs = req.body.remember
+            ? nowSecs + 30 * 24 * 60 * 60
+            : nowSecs + 24 * 60 * 60;
+        token = await new EncryptJWT({ user: username, pass: req.body.password })
+            .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+            .setIssuedAt()
+            .setExpirationTime(expSecs)
+            .encrypt(derivedKey);
+    } catch (err) {
+        return next(err);
+    }
 
     // Do not allow authentication cookies to be saved if enketo runs on http, unless 'allow insecure transport' is set to true
     // This is double because the check in login() already ensures the login screen isn't even shown.

--- a/packages/enketo-express/app/controllers/media-controller.js
+++ b/packages/enketo-express/app/controllers/media-controller.js
@@ -34,7 +34,7 @@ function _isPrintView(req) {
  */
 async function getMedia(req, res, next) {
     try {
-        const hostURLOptions = mediaLib.getHostURLOptions(req);
+        const hostURLOptions = await mediaLib.getHostURLOptions(req);
         const url = await mediaLib.getHostURL(hostURLOptions);
 
         if (url == null) {

--- a/packages/enketo-express/app/controllers/submission-controller.js
+++ b/packages/enketo-express/app/controllers/submission-controller.js
@@ -76,7 +76,7 @@ async function submit(req, res, next) {
         const survey = await surveyModel.get(id);
         const submissionUrl =
             communicator.getSubmissionUrl(survey.openRosaServer) + query;
-        const credentials = userModel.getCredentials(req);
+        const credentials = await userModel.getCredentials(req);
         const authHeader = await communicator.getAuthHeader(
             submissionUrl,
             credentials
@@ -152,9 +152,9 @@ function maxSize(req, res, next) {
     } else {
         surveyModel
             .get(req.enketoId)
-            .then((survey) => {
+            .then(async (survey) => {
                 survey.cookie = req.headers.cookie;
-                survey.credentials = userModel.getCredentials(req);
+                survey.credentials = await userModel.getCredentials(req);
 
                 return survey;
             })
@@ -191,7 +191,7 @@ async function getInstance(req, res, next) {
         const instanceAttachments = await mediaLib.getMediaMap(
             instance.instanceId,
             instance.instanceAttachments,
-            mediaLib.getHostURLOptions(req)
+            await mediaLib.getHostURLOptions(req)
         );
 
         res.json({

--- a/packages/enketo-express/app/controllers/survey-controller.js
+++ b/packages/enketo-express/app/controllers/survey-controller.js
@@ -232,8 +232,8 @@ function _renderWebform(req, res, next, options) {
 function xform(req, res, next) {
     return surveyModel
         .get(req.enketoId)
-        .then((survey) => {
-            survey.credentials = userModel.getCredentials(req);
+        .then(async (survey) => {
+            survey.credentials = await userModel.getCredentials(req);
 
             return survey;
         })

--- a/packages/enketo-express/app/controllers/transformation-controller.js
+++ b/packages/enketo-express/app/controllers/transformation-controller.js
@@ -65,7 +65,7 @@ async function getSurveyParts(req, res, next) {
         survey = await _updateCache(cached ?? survey);
 
         const { enketoId, manifest, mediaHash } = survey;
-        const mediaOptions = mediaLib.getHostURLOptions(req, mediaHash);
+        const mediaOptions = await mediaLib.getHostURLOptions(req, mediaHash);
 
         const media = await mediaLib.getMediaMap(
             enketoId,
@@ -270,13 +270,13 @@ function _getCombinedHash(survey) {
  *
  * @return { Promise<module:survey-model~SurveyObject> } a Promise resolving with survey object with added credentials
  */
-function _setCookieAndCredentials(survey, req) {
+async function _setCookieAndCredentials(survey, req) {
     // for external authentication, pass the cookie(s)
     survey.cookie = req.headers.cookie;
     // for OpenRosa authentication, add the credentials
-    survey.credentials = user.getCredentials(req);
+    survey.credentials = await user.getCredentials(req);
 
-    return Promise.resolve(survey);
+    return survey;
 }
 
 /**

--- a/packages/enketo-express/app/lib/encryption.js
+++ b/packages/enketo-express/app/lib/encryption.js
@@ -1,0 +1,13 @@
+const crypto = require('crypto');
+
+/**
+ * Derives a 32-byte Buffer from an arbitrary string for use as an AES-256-GCM key.
+ *
+ * @param {string} encryptionKeyString
+ * @return {Buffer}
+ */
+function deriveEncryptionKey(encryptionKeyString) {
+    return crypto.createHash('sha256').update(encryptionKeyString).digest();
+}
+
+module.exports = { deriveEncryptionKey };

--- a/packages/enketo-express/app/lib/media.js
+++ b/packages/enketo-express/app/lib/media.js
@@ -281,8 +281,8 @@ const rebuildMediaURLCache = async (resourceType, resourceId, options) => {
  * @param {string} [mediaHash]
  * @return {HostURLOptions}
  */
-const getHostURLOptions = (request, mediaHash) => ({
-    auth: userModel.getCredentials(request),
+const getHostURLOptions = async (request, mediaHash) => ({
+    auth: await userModel.getCredentials(request),
     basePath: request.app.get('base path') ?? '',
     cookie: request.headers.cookie,
     mediaHash,

--- a/packages/enketo-express/app/models/user-model.js
+++ b/packages/enketo-express/app/models/user-model.js
@@ -2,7 +2,8 @@
  * @module user-model
  */
 
-const jwt = require('jwt-simple');
+const { jwtDecrypt } = require('jose');
+const { deriveEncryptionKey } = require('../lib/encryption');
 const url = require('url');
 // var debug = require( 'debug' )( 'user-model' );
 
@@ -12,9 +13,9 @@ const url = require('url');
  *
  * @static
  * @param {module:api-controller~ExpressRequest} req - HTTP request
- * @return {object|null} Credentials
+ * @return {Promise<object|null>} Credentials
  */
-function getCredentials(req) {
+async function getCredentials(req) {
     const auth = req.app.get('linked form and data server').authentication;
     const authType = auth.type.toLowerCase();
     let creds = null;
@@ -22,9 +23,17 @@ function getCredentials(req) {
     if (authType === 'basic') {
         const jwToken =
             req.signedCookies[req.app.get('authentication cookie name')];
-        creds = jwToken
-            ? jwt.decode(jwToken, req.app.get('encryption key'))
-            : null;
+        if (jwToken) {
+            try {
+                const derivedKey = deriveEncryptionKey(
+                    req.app.get('encryption key')
+                );
+                const { payload } = await jwtDecrypt(jwToken, derivedKey);
+                creds = { user: payload.user, pass: payload.pass };
+            } catch {
+                creds = null;
+            }
+        }
     } else if (authType === 'token') {
         const paramName = auth['query parameter'];
         if (!paramName) {

--- a/packages/enketo-express/package.json
+++ b/packages/enketo-express/package.json
@@ -48,7 +48,7 @@
         "jstransformer-markdown-it": "^3.0.0",
         "jszip": "^3.10.1",
         "markdown-it": "^14.3.0",
-        "jwt-simple": "^0.5.6",
+        "jose": "^5.9.6",
         "libxslt": "0.10.2",
         "load-grunt-tasks": "^5.1.0",
         "lodash": "^4.18.1",

--- a/packages/enketo-express/test/server/transformation-controller.spec.js
+++ b/packages/enketo-express/test/server/transformation-controller.spec.js
@@ -77,7 +77,7 @@ describe('Transformation Controller', () => {
         // No-op `_checkQuota`
         sandbox.stub(config, 'account lib').get(() => null);
 
-        sandbox.stub(userModel, 'getCredentials').callsFake(() => ({ bearer }));
+        sandbox.stub(userModel, 'getCredentials').callsFake(() => Promise.resolve({ bearer }));
 
         app = require('../../config/express');
         basePath = app.get('base path');

--- a/packages/enketo-express/test/server/user-model.spec.js
+++ b/packages/enketo-express/test/server/user-model.spec.js
@@ -1,0 +1,80 @@
+const { expect } = require('chai');
+const { EncryptJWT } = require('jose');
+const { deriveEncryptionKey } = require('../../app/lib/encryption');
+const userModel = require('../../app/models/user-model');
+
+const ENCRYPTION_KEY = 's0m3v3rys3cr3tk3y';
+const derivedKey = deriveEncryptionKey(ENCRYPTION_KEY);
+
+function makeReq(options = {}) {
+    const { jwToken, authType = 'basic', queryParam } = options;
+    return {
+        app: {
+            get(key) {
+                if (key === 'authentication cookie name') return '__enketo_';
+                if (key === 'encryption key') return ENCRYPTION_KEY;
+                if (key === 'linked form and data server') {
+                    return {
+                        authentication: {
+                            type: authType,
+                            'query parameter': 'token',
+                        },
+                    };
+                }
+            },
+        },
+        signedCookies: { '__enketo_': jwToken },
+        query: queryParam ? { token: queryParam } : {},
+        headers: {},
+    };
+}
+
+async function makeValidToken(overrides = {}) {
+    const nowSecs = Math.floor(Date.now() / 1000);
+    return new EncryptJWT({ user: 'alice', pass: 'secret', ...overrides })
+        .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+        .setIssuedAt()
+        .setExpirationTime(nowSecs + 3600)
+        .encrypt(derivedKey);
+}
+
+describe('user-model', () => {
+    describe('getCredentials', () => {
+        it('returns credentials from a valid JWE token', async () => {
+            const token = await makeValidToken();
+            const creds = await userModel.getCredentials(makeReq({ jwToken: token }));
+            expect(creds).to.deep.equal({ user: 'alice', pass: 'secret' });
+        });
+
+        it('returns null for an expired JWE token', async () => {
+            const nowSecs = Math.floor(Date.now() / 1000);
+            const token = await new EncryptJWT({ user: 'alice', pass: 'secret' })
+                .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+                .setIssuedAt()
+                .setExpirationTime(nowSecs - 10)
+                .encrypt(derivedKey);
+
+            const creds = await userModel.getCredentials(makeReq({ jwToken: token }));
+            expect(creds).to.be.null;
+        });
+
+        it('returns null for an old signed JWT (pre-migration token)', async () => {
+            // jwt-simple produces a 3-part compact JWS; jwtDecrypt expects a 5-part JWE
+            const oldToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYWxpY2UiLCJwYXNzIjoic2VjcmV0In0.fakeSignature';
+            const creds = await userModel.getCredentials(makeReq({ jwToken: oldToken }));
+            expect(creds).to.be.null;
+        });
+
+        it('returns null when no cookie is present', async () => {
+            const creds = await userModel.getCredentials(makeReq({ jwToken: undefined }));
+            expect(creds).to.be.null;
+        });
+
+        it('returns bearer credentials for token auth type', async () => {
+            const creds = await userModel.getCredentials(
+                makeReq({ authType: 'token', queryParam: 'mytoken123' })
+            );
+            expect(creds).to.deep.equal({ bearer: 'mytoken123' });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Closes #1590.

The auth cookie stored a **signed** JWT (`jwt-simple`, HS256) with `{ user, pass }` in the payload. Because signing does not encrypt, anyone who reads the cookie can base64-decode the payload and recover the plaintext password without any key material.

This PR switches to **encrypted JWTs (JWE)** using [`jose`](https://github.com/panva/jose) with `alg: dir, enc: A256GCM`:

- **`app/lib/encryption.js`** (new) — derives a 32-byte AES key from the existing `encryption key` config string via SHA-256, so no config changes are required
- **`authentication-controller.js`** — `setToken` uses `EncryptJWT`; also adds `iat`/`exp` claims (24 h default, 30 d with "remember me") so tokens expire server-side
- **`user-model.js`** — `getCredentials` uses `jwtDecrypt`; any decryption failure (expired, tampered, or pre-migration signed token) returns `null`, forcing re-login
- **`package.json`** — replaces `jwt-simple` with `jose ^5.9.6`
- All `getCredentials` / `getHostURLOptions` call sites updated for the new async API
- **`test/server/user-model.spec.js`** (new) — 5 unit tests: valid JWE, expired token, old JWS token (migration compat), missing cookie, token auth type

**Breaking change for existing sessions:** tokens issued before this change are signed JWTs (3-part compact JWS). `jwtDecrypt` rejects them as invalid JWE, returning `null` — users will need to log in again once after deployment.

## Test plan

- [ ] `node_modules/.bin/mocha packages/enketo-express/test/server/user-model.spec.js` — all 5 tests pass
- [ ] Log in via `/login`, inspect the `__enketo_` cookie — should be a 5-part compact JWE string instead of a 3-part JWS
- [ ] Submit a form with basic auth — confirm credentials are forwarded correctly to the OpenRosa server
- [ ] Log out and log back in with "remember me" checked — confirm 30-day expiry token is issued
- [ ] Paste an old-style signed token into the cookie manually — confirm the app treats it as unauthenticated (redirects to login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)