### PR TITLE
fix(submissions): keep defaults for multiple submissions DEV-2716

### DIFF
--- a/packages/enketo-express/public/js/src/enketo-webform.js
+++ b/packages/enketo-express/public/js/src/enketo-webform.js
@@ -279,10 +279,11 @@ export function getValidatedDefaults(modelStr, defaults) {
     const validated = {};
 
     for (const path in defaults) {
-        if (!Object.prototype.hasOwnProperty.call(defaults, path)) continue;
-        const targetNode = model.node(path).getElement();
-        if (_isAllowedDefault(path, targetNode, model.rootElement)) {
-            validated[path] = defaults[path];
+        if (Object.prototype.hasOwnProperty.call(defaults, path)) {
+            const targetNode = model.node(path).getElement();
+            if (_isAllowedDefault(path, targetNode, model.rootElement)) {
+                validated[path] = defaults[path];
+            }
         }
     }
 
@@ -305,13 +306,13 @@ function _prepareInstance(modelStr, validatedDefaults) {
     let instanceStr = null;
 
     for (const path in validatedDefaults) {
-        if (!Object.prototype.hasOwnProperty.call(validatedDefaults, path))
-            continue;
-        // TODO: would be good to not include nodes that weren't in the defaults parameter
-        // HOWEVER, that would also set number of repeats to 0, which may be undesired
-        // TODO: would be good to just pass model along instead of converting to string first
-        model.node(path).setVal(validatedDefaults[path]);
-        instanceStr = model.getStr();
+        if (Object.prototype.hasOwnProperty.call(validatedDefaults, path)) {
+            // TODO: would be good to not include nodes that weren't in the defaults parameter
+            // HOWEVER, that would also set number of repeats to 0, which may be undesired
+            // TODO: would be good to just pass model along instead of converting to string first
+            model.node(path).setVal(validatedDefaults[path]);
+            instanceStr = model.getStr();
+        }
     }
 
     return instanceStr;

--- a/packages/enketo-express/public/js/src/enketo-webform.js
+++ b/packages/enketo-express/public/js/src/enketo-webform.js
@@ -261,32 +261,60 @@ function _isAllowedDefault(path, targetNode, rootElement) {
     return true;
 }
 
-export function _prepareInstance(modelStr, defaults) {
-    let model;
-    let init;
-    let existingInstance = null;
+/**
+ * Validates URL default parameters against the form model and returns only
+ * the subset that are safe to apply. This is the security gate for d[path]=value
+ * query parameters — paths targeting attributes, group nodes, the instance root,
+ * or protected ODK metadata fields are silently dropped.
+ *
+ * @param {string} modelStr - XForm model XML string
+ * @param {object} defaults - raw d[path]=value map from URL query params
+ * @return {object} filtered map containing only allowed path/value pairs
+ */
+export function getValidatedDefaults(modelStr, defaults) {
+    if (!defaults || !Object.keys(defaults).length) return {};
+
+    const model = new FormModel(modelStr, { full: false });
+    model.init();
+    const validated = {};
 
     for (const path in defaults) {
-        if (Object.prototype.hasOwnProperty.call(defaults, path)) {
-            model =
-                model ||
-                new FormModel(modelStr, {
-                    full: false,
-                });
-            init = init || model.init();
-            const targetNode = model.node(path).getElement();
-            if (_isAllowedDefault(path, targetNode, model.rootElement)) {
-                // if this fails, the FormModel will output a console error and ignore the instruction
-                model.node(path).setVal(defaults[path]);
-                // TODO: would be good to not include nodes that weren't in the defaults parameter
-                // HOWEVER, that would also set number of repeats to 0, which may be undesired
-                // TODO: would be good to just pass model along instead of converting to string first
-                existingInstance = model.getStr();
-            }
+        if (!Object.prototype.hasOwnProperty.call(defaults, path)) continue;
+        const targetNode = model.node(path).getElement();
+        if (_isAllowedDefault(path, targetNode, model.rootElement)) {
+            validated[path] = defaults[path];
         }
     }
 
-    return existingInstance;
+    return validated;
+}
+
+/**
+ * Applies pre-validated defaults to a fresh model instance and returns the
+ * serialized XML string for use as instanceStr on form initialization.
+ *
+ * @param {string} modelStr - XForm model XML string
+ * @param {object} validatedDefaults - already-validated path/value map from getValidatedDefaults
+ * @return {string|null} instance XML string, or null if no defaults to apply
+ */
+function _prepareInstance(modelStr, validatedDefaults) {
+    if (!Object.keys(validatedDefaults).length) return null;
+
+    const model = new FormModel(modelStr, { full: false });
+    model.init();
+    let instanceStr = null;
+
+    for (const path in validatedDefaults) {
+        if (!Object.prototype.hasOwnProperty.call(validatedDefaults, path))
+            continue;
+        // TODO: would be good to not include nodes that weren't in the defaults parameter
+        // HOWEVER, that would also set number of repeats to 0, which may be undesired
+        // TODO: would be good to just pass model along instead of converting to string first
+        model.node(path).setVal(validatedDefaults[path]);
+        instanceStr = model.getStr();
+    }
+
+    return instanceStr;
 }
 
 function _init(formParts) {
@@ -294,10 +322,16 @@ function _init(formParts) {
     formheader.after(formFragment);
     const formEl = document.querySelector('form.or');
 
+    const validatedDefaults = getValidatedDefaults(
+        formParts.model,
+        settings.defaults
+    );
+
     return controller
         .init(formEl, {
             modelStr: formParts.model,
-            instanceStr: _prepareInstance(formParts.model, settings.defaults),
+            instanceStr: _prepareInstance(formParts.model, validatedDefaults),
+            validatedDefaults,
             external: formParts.externalData,
             survey: formParts,
         })

--- a/packages/enketo-express/public/js/src/module/controller-webform.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform.js
@@ -44,6 +44,7 @@ const formOptions = {
  * @typedef ControllerWebformInitData
  * @property {string} modelStr
  * @property {string} instanceStr
+ * @property {object} [validatedDefaults] - pre-validated URL default values from getValidatedDefaults
  * @property {Document[]} external
  * @property {Survey} survey
  * @property {InstanceAttachment[]} [instanceAttachments]
@@ -247,6 +248,14 @@ function _resetForm(survey, options = {}) {
             replaceModelMediaSources(form, survey.media);
 
             const loadErrors = form.init();
+
+            const { validatedDefaults } = formData;
+            if (validatedDefaults && Object.keys(validatedDefaults).length) {
+                for (const [path, value] of Object.entries(validatedDefaults)) {
+                    form.model.node(path).setVal(value);
+                }
+                form.setAllVals();
+            }
 
             form.view.html.dispatchEvent(events.FormReset());
 

--- a/packages/enketo-express/test/client/feature/url-defaults.spec.js
+++ b/packages/enketo-express/test/client/feature/url-defaults.spec.js
@@ -1,4 +1,4 @@
-import { _prepareInstance } from '../../../public/js/src/enketo-webform';
+import { getValidatedDefaults } from '../../../public/js/src/enketo-webform';
 
 const MODEL = `<model>
   <instance>
@@ -15,98 +15,86 @@ const MODEL = `<model>
   </instance>
 </model>`;
 
-describe('URL defaults (_prepareInstance)', () => {
-    const parser = new DOMParser();
+describe('URL defaults (getValidatedDefaults)', () => {
+    it('includes a valid leaf node path', () => {
+        const result = getValidatedDefaults(MODEL, { '/myform/name': 'Alice' });
 
-    it('applies a default value to a matching leaf node', () => {
-        const result = _prepareInstance(MODEL, { '/myform/name': 'Alice' });
-        const doc = parser.parseFromString(result, 'text/xml');
-
-        expect(doc.querySelector('name').textContent).to.equal('Alice');
+        expect(result).to.deep.equal({ '/myform/name': 'Alice' });
     });
 
-    it('returns null when defaults is empty', () => {
-        expect(_prepareInstance(MODEL, {})).to.be.null;
+    it('returns an empty object when defaults is empty', () => {
+        expect(getValidatedDefaults(MODEL, {})).to.deep.equal({});
     });
 
-    it('applies multiple defaults independently', () => {
-        const result = _prepareInstance(MODEL, {
+    it('includes multiple valid paths', () => {
+        const result = getValidatedDefaults(MODEL, {
             '/myform/name': 'Bob',
             '/myform/age': '30',
         });
-        const doc = parser.parseFromString(result, 'text/xml');
 
-        expect(doc.querySelector('name').textContent).to.equal('Bob');
-        expect(doc.querySelector('age').textContent).to.equal('30');
+        expect(result).to.deep.equal({ '/myform/name': 'Bob', '/myform/age': '30' });
     });
 
-    it('rejects a path targeting the primary instance root', () => {
-        const result = _prepareInstance(MODEL, { '/myform': 'injected' });
-        // rejected path produces no instance output
-        expect(result).to.be.null;
+    it('excludes a path targeting the primary instance root', () => {
+        const result = getValidatedDefaults(MODEL, { '/myform': 'injected' });
+
+        expect(result).to.deep.equal({});
     });
 
-    it('rejects a path targeting an attribute of the primary instance root', () => {
-        const result = _prepareInstance(MODEL, { '/myform/@id': 'injected' });
-        expect(result).to.be.null;
+    it('excludes a path targeting an attribute of the primary instance root', () => {
+        const result = getValidatedDefaults(MODEL, { '/myform/@id': 'injected' });
+
+        expect(result).to.deep.equal({});
     });
 
-    it('rejects a path targeting an attribute of a field', () => {
-        const result = _prepareInstance(MODEL, {
+    it('excludes attribute paths while keeping valid sibling paths', () => {
+        const result = getValidatedDefaults(MODEL, {
             '/myform/name': 'Alice',
             '/myform/name/@someattr': 'injected',
         });
-        const doc = parser.parseFromString(result, 'text/xml');
-        expect(doc.querySelector('name').textContent).to.equal('Alice');
-        expect(doc.querySelector('name').hasAttribute('someattr')).to.be.false;
+
+        expect(result).to.deep.equal({ '/myform/name': 'Alice' });
     });
 
-    it('allows a field whose name matches a protected meta field name but is outside meta', () => {
-        const result = _prepareInstance(MODEL, {
+    it('includes a field whose name matches a protected meta field name but is outside meta', () => {
+        const result = getValidatedDefaults(MODEL, {
             '/myform/email': 'test@example.com',
         });
-        const doc = parser.parseFromString(result, 'text/xml');
-        expect(doc.querySelector('email').textContent).to.equal(
-            'test@example.com'
-        );
+
+        expect(result).to.deep.equal({ '/myform/email': 'test@example.com' });
     });
 
-    it('rejects a path targeting a protected meta field', () => {
-        const result = _prepareInstance(MODEL, {
+    it('excludes a path targeting a protected meta field', () => {
+        const result = getValidatedDefaults(MODEL, {
             '/myform/name': 'Alice',
             '/myform/meta/instanceID': 'fixed-uuid',
         });
-        const doc = parser.parseFromString(result, 'text/xml');
-        expect(doc.querySelector('name').textContent).to.equal('Alice');
-        expect(doc.querySelector('instanceID').textContent).to.not.equal(
-            'fixed-uuid'
-        );
+
+        expect(result).to.deep.equal({ '/myform/name': 'Alice' });
     });
 
-    it('allows a default on a field nested inside a group', () => {
-        const result = _prepareInstance(MODEL, {
+    it('includes a field nested inside a group', () => {
+        const result = getValidatedDefaults(MODEL, {
             '/myform/respondent/first_name': 'Alice',
         });
-        const doc = parser.parseFromString(result, 'text/xml');
-        expect(doc.querySelector('first_name').textContent).to.equal('Alice');
+
+        expect(result).to.deep.equal({ '/myform/respondent/first_name': 'Alice' });
     });
 
-    it('rejects a path targeting a group element', () => {
-        const result = _prepareInstance(MODEL, {
+    it('excludes a path targeting a group element', () => {
+        const result = getValidatedDefaults(MODEL, {
             '/myform/respondent': 'injected',
         });
-        expect(result).to.be.null;
+
+        expect(result).to.deep.equal({});
     });
 
-    it('rejects a path outside the primary instance entirely', () => {
-        const result = _prepareInstance(MODEL, {
+    it('excludes paths outside the primary instance while keeping valid ones', () => {
+        const result = getValidatedDefaults(MODEL, {
             '/myform/name': 'Alice',
             '/other/field': 'injected',
         });
-        const doc = parser.parseFromString(result, 'text/xml');
-        // valid path still applied
-        expect(doc.querySelector('name').textContent).to.equal('Alice');
-        // no 'other' element was created
-        expect(doc.querySelector('other')).to.be.null;
+
+        expect(result).to.deep.equal({ '/myform/name': 'Alice' });
     });
 });

--- a/packages/enketo-express/test/client/feature/url-defaults.spec.js
+++ b/packages/enketo-express/test/client/feature/url-defaults.spec.js
@@ -32,7 +32,10 @@ describe('URL defaults (getValidatedDefaults)', () => {
             '/myform/age': '30',
         });
 
-        expect(result).to.deep.equal({ '/myform/name': 'Bob', '/myform/age': '30' });
+        expect(result).to.deep.equal({
+            '/myform/name': 'Bob',
+            '/myform/age': '30',
+        });
     });
 
     it('excludes a path targeting the primary instance root', () => {
@@ -42,7 +45,9 @@ describe('URL defaults (getValidatedDefaults)', () => {
     });
 
     it('excludes a path targeting an attribute of the primary instance root', () => {
-        const result = getValidatedDefaults(MODEL, { '/myform/@id': 'injected' });
+        const result = getValidatedDefaults(MODEL, {
+            '/myform/@id': 'injected',
+        });
 
         expect(result).to.deep.equal({});
     });
@@ -78,7 +83,9 @@ describe('URL defaults (getValidatedDefaults)', () => {
             '/myform/respondent/first_name': 'Alice',
         });
 
-        expect(result).to.deep.equal({ '/myform/respondent/first_name': 'Alice' });
+        expect(result).to.deep.equal({
+            '/myform/respondent/first_name': 'Alice',
+        });
     });
 
     it('excludes a path targeting a group element', () => {


### PR DESCRIPTION
### 📣 Summary

URL pre-filled default values now persist across multiple submissions in offline-capable forms.

### 📖 Description

When a form URL includes pre-filled field values via query parameters (e.g. `?d[participant_id]=12345`), those values are now correctly re-applied each time the form resets after a successful submission. Previously, only the first submission in a session would carry the pre-filled value; subsequent submissions showed a blank field, requiring the user to manually refresh the page to restore the default.

### 💭 Notes

**Root cause:** After a successful submission, `_resetForm()` re-initialised the form from the blank XForm model, but never re-applied the URL defaults. The `settings.defaults` map was still in memory and the URL was unchanged, but nothing called `_prepareInstance` again.

**What changed:**

- `enketo-webform.js`: The URL-defaults logic is now split into two functions with distinct responsibilities:
  - `getValidatedDefaults(modelStr, defaults)` *(new, exported)* — the security gate. Validates each `d[path]=value` URL param against the form model using the existing `_isAllowedDefault` checks (blocks attributes, group nodes, the instance root, and protected ODK metadata fields like `instanceID`). Returns only the safe subset.
  - `_prepareInstance(modelStr, validatedDefaults)` *(now private)* — unchanged in behaviour, but now accepts pre-validated defaults rather than raw URL params, since the validation responsibility has been lifted out.
  - On form initialisation, both are called; `validatedDefaults` is passed into `controller.init()` alongside `instanceStr`.

- `controller-webform.js`: `_resetForm()` now re-applies `formData.validatedDefaults` after `form.init()` using `setVal` + `setAllVals()`. The controller itself has no knowledge of validation rules — it just applies what it was given.

- `url-defaults.spec.js`: Tests now cover `getValidatedDefaults` (where the security behaviour lives) rather than `_prepareInstance`.

### 👀 Preview steps

1. ℹ️ Have a form with a text field (e.g. `participant_id`) and a second unrelated text field
2. Obtain its Enketo URL and append `?d[participant_id]=TEST123`
3. Navigate to the online-offline form URL 
4. 🔴 **[on main]** Notice `TEST123` is pre-filled in `participant_id` on first load ✓
5. Fill in the second field and submit successfully
6. 🔴 **[on main]** Notice `participant_id` is now blank on the reset form — the default did not return
7. 🟢 **[on PR]** Notice `TEST123` is pre-filled again after submission, without needing to refresh
8. 🟢 **[on PR]** Submit again and confirm the second submission succeeds
