### PR TITLE
fix(autosave): avoid auto save on re-initialized forms DEV-2717

### DIFF
--- a/packages/enketo-express/public/js/src/module/controller-webform.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform.js
@@ -223,7 +223,11 @@ function _checkAutoSavedRecord() {
  * @param {ResetFormOptions} [options]
  * @return {Promise<void>}
  */
+let _isResetting = false;
+
 function _resetForm(survey, options = {}) {
+    _isResetting = true;
+
     return getLastSavedRecord(survey.enketoId)
         .then((lastSavedRecord) =>
             populateLastSavedInstances(survey, lastSavedRecord)
@@ -257,6 +261,9 @@ function _resetForm(survey, options = {}) {
             if (loadErrors.length > 0) {
                 gui.alertLoadErrors(loadErrors);
             }
+        })
+        .finally(() => {
+            _isResetting = false;
         });
 }
 
@@ -613,9 +620,9 @@ function _saveRecord(survey, draft, recordName, confirmed) {
 
             return records.save(saveMethod, record);
         })
-        .then(() => {
-            records.removeAutoSavedRecord();
-            _resetForm(survey, { isOffline: true });
+        .then(async () => {
+            await records.removeAutoSavedRecord();
+            await _resetForm(survey, { isOffline: true });
 
             if (draft) {
                 gui.alert(
@@ -659,9 +666,10 @@ function _saveRecord(survey, draft, recordName, confirmed) {
 let autoSavePromise = Promise.resolve();
 
 function _autoSaveRecord() {
-    // Do not auto-save a record if the record was loaded from storage
-    // or if the form has enabled encryption
-    if (form.recordName || form.encryptionKey) {
+    // Do not auto-save a record if the record was loaded from storage,
+    // if the form has enabled encryption, or if the form is currently being
+    // reset (e.g. after a submission).
+    if (form.recordName || form.encryptionKey || _isResetting) {
         return autoSavePromise;
     }
 


### PR DESCRIPTION
### 📣 Summary

After submitting a form in offline-enabled mode, Enketo no longer auto-saves reinitialized form prior to user input.

### 💭 Notes

**Root cause:** After a successful offline submission, the form resets to a blank state. During that reset, `form.init()` dispatches `XFormsValueChanged` events (triggered by calc fields and defaults being re-evaluated), which fired the auto-save listener and immediately re-created an auto-save record — usually before the deletion of the old one had even settled. The next visit found this blank auto-save record and showed the modal.

**Fix:** `_resetForm` now sets an `_isResetting` flag at entry (cleared in `.finally()`) that causes `_autoSaveRecord` to no-op during the reset window.

**Alternatives considered:** Comparing the current form XML to a "pristine" snapshot on every save to skip saving unmodified forms would be semantically cleaner, but this architecture doesn't have a first-class notion of form dirtiness, and `getDataStr()` (XML DOM serialization) would have to run on every `XFormsValueChanged` event.

### 👀 Preview steps

1. Open a form in online-offline mode and submit it
3. Navigate away and return to the form (or reload the page)
4. 🔴 [on main] The "Unsaved Record Found" modal appears, asking whether to load or discard a (untouched) form
5. 🟢 [on PR] The form opens cleanly with no modal
